### PR TITLE
A few more typos and suggestions

### DIFF
--- a/III_M/differential_geometry.tex
+++ b/III_M/differential_geometry.tex
@@ -13,28 +13,28 @@
 {\small
 \setlength{\parindent}{0em}
 \setlength{\parskip}{1em}
-This course is intended as an introduction to modern differential geometry. It can be taken with a view to further studies in Geometry and Topology and should also be suitable as a supplementary course if your main interests are for instance in Analysis or Mathematical Physics. A tentative syllabus is as follows.
+This course is intended as an introduction to modern differential geometry. It can be taken with a view to further studies in Geometry and Topology and should also be suitable as a supplementary course if your main interests are, for instance, in Analysis or Mathematical Physics. A tentative syllabus is as follows.
 
 \begin{itemize}[label={$\bullet$}]
   \item \emph{Local Analysis and Differential Manifolds.} Definition and examples of manifolds, smooth maps. Tangent vectors and vector fields, tangent bundle. Geometric consequences of the implicit function theorem, submanifolds. Lie Groups.
 
-  \item \emph{Vector Bundles.} Structure group. The example of Hopf bundle. Bundle morphisms and automorphisms. Exterior algebra of differential forms. Tensors. Symplectic forms. Orientability of manifolds. Partitions of unity and integration on manifolds, Stokes Theorem; de Rham cohomology. Lie derivative of tensors. Connections on vector bundles and covariant derivatives: covariant exterior derivative, curvature. Bianchi identity.
+  \item \emph{Vector Bundles.} Structure group. The example of Hopf bundle. Bundle morphisms and automorphisms. Exterior algebra of differential forms. Tensors. Symplectic forms. Orientability of manifolds. Partitions of unity and integration on manifolds, Stokes' Theorem; de Rham cohomology. Lie derivative of tensors. Connections on vector bundles and covariant derivatives: covariant exterior derivative, curvature. Bianchi identity.
 
   \item \emph{Riemannian Geometry.} Connections on the tangent bundle, torsion. Bianchi's identities for torsion free connections. Riemannian metrics, Levi-Civita connection, Christoffel symbols, geodesics. Riemannian curvature tensor and its symmetries, second Bianchi identity, sectional curvatures.
 \end{itemize}
 
 \subsubsection*{Pre-requisites}
-An essential pre-requisite is a working knowledge of linear algebra (including bilinear forms) and multivariate calculus (eg. differentiation and Taylor's theorem in several variables). Exposure to some of the ideas of classical differential geometry might also be useful.
+An essential pre-requisite is a working knowledge of linear algebra (including bilinear forms) and multivariate calculus (e.g.\ differentiation and Taylor's theorem in several variables). Exposure to some of the ideas of classical differential geometry might also be useful.
 }
 \tableofcontents
 
 \setcounter{section}{-1}
 \section{Introduction}
-In differential geometry, the main object of study is a \emph{manifold}. The motivation is as follows --- from IA, we know well how to do calculus on $\R^n$. We can talk about continuity, differentiable functions, derivatives etc. happily ever after.
+In differential geometry, the main object of study is a \emph{manifold}. The motivation is as follows --- from IA, we know well how to do calculus on $\R^n$. We can talk about continuity, differentiable functions, derivatives etc.\ happily ever after.
 
 However, sometimes, we want to do calculus on things other than $\R^n$. Say, we live on a sphere, namely the Earth. Does it make sense to ``do calculus'' on a sphere? Surely it does.
 
-The key insight is that these notions of differentiability, derivatives etc. are \emph{local} properties. To know if a function is differentiable at a point $p$, we only need to know how the function behaves near $p$, and similarly such local information tells us how to compute derivatives. The reason we can do calculus on a sphere is because the sphere looks \emph{locally} like $\R^n$. Therefore we can make sense of calculus on a sphere.
+The key insight is that these notions of differentiability, derivatives etc.\ are \emph{local} properties. To know if a function is differentiable at a point $p$, we only need to know how the function behaves near $p$, and similarly such local information tells us how to compute derivatives. The reason we can do calculus on a sphere is because the sphere looks \emph{locally} like $\R^n$. Therefore, we can make sense of calculus on a sphere.
 
 Thus, what we want to do is to study calculus on things that look \emph{locally} like $\R^n$, and these are known as manifolds. Most of the time, our definitions from usual calculus on $\R^n$ transfer directly to manifolds. However, sometimes the global properties of our manifold will give us some new exciting things.
 
@@ -75,7 +75,7 @@ Note that we do not require $U$ to be open in $M$, or $\varphi$ to be a homeomor
 \end{center}
 With a chart, we can talk about things like continuity, differentiability by identifying $U$ with $\varphi(U)$:
 \begin{defi}[Smooth function]\index{smooth function}\index{$C^\infty$}
-  Let $(U, \varphi)$ be a chart on $M$, and $f: M \to \R$, we say $f$ is \emph{smooth} or $C^\infty$ at $p \in U$ if $f \circ \varphi^{-1}: \varphi(U) \to \R$ is smooth at $\varphi(p)$ in the usual sense.
+  Let $(U, \varphi)$ be a chart on $M$ and $f: M \to \R$. We say $f$ is \emph{smooth} or $C^\infty$ at $p \in U$ if $f \circ \varphi^{-1}: \varphi(U) \to \R$ is smooth at $\varphi(p)$ in the usual sense.
   \[
     \begin{tikzcd}
       \R^n \supseteq \varphi(U) \ar[r, "\varphi^{-1}"] & U \ar[r, "f"] & \R
@@ -107,7 +107,7 @@ With a chart, we can talk about things like continuity, differentiability by ide
 
   \end{tikzpicture}
 \end{center}
-We can define all other notions such as continuity, differentiability, twice differentiability etc. similarly.
+We can define all other notions such as continuity, differentiability, twice differentiability etc.\ similarly.
 
 This definition has a problem that some points might not be in the chart, and we don't know how to determine if a function is, say, smooth at the point. The solution is easy --- we just take many charts that together cover $M$. However, we have the problem that a function might be smooth at a point relative to some chart, but not relative to some other chart. The solution is to require the charts to be compatible in some sense.
 
@@ -173,7 +173,7 @@ So we know that if we have an atlas on a set, then the notion of smoothness does
 \begin{eg}
   Consider the sphere
   \[
-    S^2 = \{(x_1, x_2, x_2): \sum x_i^2 = 1\} \subseteq \R^3.
+    S^2 = \{(x_1, x_2, x_3): \sum x_i^2 = 1\} \subseteq \R^3.
   \]
   We let
   \[
@@ -190,7 +190,7 @@ So we know that if we have an atlas on a set, then the notion of smoothness does
 \begin{defi}[Equivalent atlases]\index{equivalent atlases}\index{atlas!equivalence}
   Two atlases $\mathcal{A}_1$ and $\mathcal{A}_2$ are \emph{equivalent} if $\mathcal{A}_1 \cup \mathcal{A}_2$ is an atlas.
 \end{defi}
-Then equivalent atlases determine the same smoothness, continuity etc. information.
+Then equivalent atlases determine the same smoothness, continuity etc.\ information.
 
 \begin{defi}[Differentiable structure]\index{differentiable structure}
   A \emph{differentiable structure} on $M$ is a choice of equivalence class of atlases.
@@ -227,8 +227,8 @@ We now get to the definition of a manifold.
 \begin{defi}[Manifold]\index{manifold}
   A \emph{manifold} is a set $M$ with a choice of differentiable structure whose topology is
   \begin{enumerate}
-    \item Hausdorff\index{Hausdorff}, ie. for all $x, y \in M$, there are open neighbourhoods $U_x, U_y \subseteq M$ with $x \in U_x, y \in U_y$ and $U_x \cap U_y = \emptyset$.
-    \item Second countable\index{second countable}, ie. there exists a countable collection $(U_n)_{n \in \N}$ of open sets in $M$ such that for all $V \subseteq M$ open, and $p \in V$, there is some $n$ such that $p \in U_n \subseteq V$.
+    \item Hausdorff\index{Hausdorff}, i.e.\ for all $x, y \in M$, there are open neighbourhoods $U_x, U_y \subseteq M$ with $x \in U_x, y \in U_y$ and $U_x \cap U_y = \emptyset$.
+    \item Second countable\index{second countable}, i.e.\ there exists a countable collection $(U_n)_{n \in \N}$ of open sets in $M$ such that for all $V \subseteq M$ open, and $p \in V$, there is some $n$ such that $p \in U_n \subseteq V$.
   \end{enumerate}
 \end{defi}
 The second countability condition is a rather technical condition that we wouldn't really use much. This, for example, excludes the long line.
@@ -253,7 +253,7 @@ By abuse of notation, if $f: M \to \R$, we confuse $f|_U$ and $f \circ \varphi^{
     \varphi(U) \ar[rru, "f|_U"']
   \end{tikzcd}
 \]
-Of course, we can similarly define $C^0, C^1, C^2, \cdots$ manifolds, or analytic manifolds. We can also model manifolds on other spaces, eg. $\C^n$, where we get complex manifolds, or on infinite-dimensional spaces.
+Of course, we can similarly define $C^0, C^1, C^2, \cdots$ manifolds, or analytic manifolds. We can also model manifolds on other spaces, e.g.\ $\C^n$, where we get complex manifolds, or on infinite-dimensional spaces.
 
 \begin{eg}\leavevmode
   \begin{enumerate}
@@ -298,7 +298,7 @@ From now on, $M$ and $N$ will be manifolds. As usual, we would like to talk abou
 
   A \term{diffeomorphism} is a smooth $f$ with a smooth inverse.
 
-  We write $C^\infty(M, N)$ \index{$C^\infty(M, N)$} for the space of smooth maps $f: M \to N$. We write $C^\infty(M)$\index{$C^\infty(M)$} for $C^\infty(M, \R)$, and this has the additional structure of an algebra, ie. vector space with multiplication.
+  We write $C^\infty(M, N)$ \index{$C^\infty(M, N)$} for the space of smooth maps $f: M \to N$. We write $C^\infty(M)$\index{$C^\infty(M)$} for $C^\infty(M, \R)$, and this has the additional structure of an algebra, i.e.\ a vector space with multiplication.
 \end{defi}
 \begin{center}
   \begin{tikzpicture}
@@ -346,7 +346,7 @@ To discuss derivatives, we first look at the case where $U \subseteq \R^n$ is op
 \[
   Df|_p(\mathbf{v}) = \lim_{t \to 0} \frac{f(p + t\mathbf{v}) - f(p)}{t}.
 \]
-If $\mathbf{v} = \mathbf{e}_i = (0, \cdots, 1, 0, \cdots, 0)$, then we write
+If $\mathbf{v} = \mathbf{e}_i = (0, \cdots, 0, 1, 0, \cdots, 0)$, then we write
 \[
   Df|_p (\mathbf{e}_i) = \left.\frac{\partial f}{\partial x_i}\right|_p.
 \]
@@ -375,7 +375,7 @@ We denote $X$ by $\dot{\gamma}(0)$. We might think of defining the tangent space
 \begin{defi}[Tangent space]\index{tangent space}
   Let $p \in U \subseteq M$, where $U$ is open. The \emph{tangent space} of $M$ at $p$ is the vector space
   \[
-    T_p(M) = \{\text{derivations on $U$ at $p$}\}.
+    T_p M = \{ \, \text{derivations on $U$ at $p$} \, \}.
   \]
   The subscript $p$ tells us the point at which we are taking the tangent space.
 \end{defi}
@@ -389,7 +389,7 @@ We will do the first part at the end by bump functions, and will do the second p
 \begin{eg}\index{$\frac{\partial}{\partial x_i}$}
   Let $U \subseteq \R^n$ be open, and let $p \in U$. Then we have tangent vectors
   \[
-    \left.\frac{\partial}{\partial x_i}\right|_p \in T_p \R^n.
+    \left.\frac{\partial}{\partial x_i}\right|_p \in T_p \R^n, \qquad i = 1, \ldots, n.
   \]
   These correspond to the canonical basis vectors in $\R^n$.
 \end{eg}
@@ -405,7 +405,7 @@ The idea of the proof is to show that a derivation can only depend on the first 
   \[
     \frac{\partial x_j}{\partial x_i} = \delta_{ij}.
   \]
-  We need to show spanning. For notational convenience, we wlog $p = 0$. Let $X \in T_0 \R^n$.
+  We need to show spanning. For notational convenience, we wlog take $p = 0$. Let $X \in T_0 \R^n$.
 
   We first show that if $g \in C^\infty(U)$ is the constant function $g = 1$, then $X(g) = 0$. Indeed, we have
   \[
@@ -415,7 +415,7 @@ The idea of the proof is to show that a derivation can only depend on the first 
 
   In general, let $f \in C^\infty(U)$. By Taylor's theorem, we have
   \[
-    f(x_1, \cdots, x_n) = f(0) + \sum \frac{\partial f}{\partial x_i} x_i + \varepsilon,
+    f(x_1, \cdots, x_n) = f(0) + \sum_{i = 1}^n \left.\frac{\partial f}{\partial x_i}\right|_0 x_i + \varepsilon,
   \]
   where $\varepsilon$ is a sum of terms of the form $x_i x_j h$ with $h \in C^\infty(U)$.
 
@@ -425,11 +425,11 @@ The idea of the proof is to show that a derivation can only depend on the first 
   \]
   So we have
   \[
-    X(f) = \sum \lambda_i \left.\frac{\partial f}{\partial x_i}\right|_0.
+    X(f) = \sum_{i = 1}^n \lambda_i \left.\frac{\partial f}{\partial x_i}\right|_0.
   \]
   So we have
   \[
-    X = \sum \lambda_i \left.\frac{\partial}{\partial x_i}\right|_0.
+    X = \sum_{i = 1}^n \lambda_i \left.\frac{\partial}{\partial x_i}\right|_0.
   \]
 \end{proof}
 
@@ -459,9 +459,9 @@ With a silly definition of a derivative comes a silly definition of the chain ru
 \end{prop}
 
 \begin{proof}
-  We have
+  Let $h \in C^\infty(P)$ and $X \in T_p M$. We have
   \[
-    \D G|_q (\D F|_p (X))(h) = \D F|_p(X) (h \circ G) = X(h \circ G \circ F) = \D (G \circ F)|_p (X).
+    \D G|_q (\D F|_p (X))(h) = \D F|_p(X) (h \circ G) = X(h \circ G \circ F) = \D (G \circ F)|_p (X). \qedhere
   \]
 \end{proof}
 Note that this does not provide a new, easy proof of the chain rule. Indeed, to come this far into the course, we have used the actual chain rule something like ten thousand times.
@@ -478,15 +478,15 @@ In the special case where the domain is $\R$, there is a canonical choice of tan
   \]
 \end{defi}
 
-We now go back to understanding what $T_pM$ is if $p \in M$. We let $p \in U$ where $(U, \varphi)$ is a chart. Then if $q = \varphi(p)$, the map $D\varphi|_p: T_p M \to T_q \R^n$ is a linear isomorphism.
+We now go back to understanding what $T_pM$ is if $p \in M$. We let $p \in U$ where $(U, \varphi)$ is a chart. Then if $q = \varphi(p)$, the map $\D\varphi|_p: T_p M \to T_q \R^n$ is a linear isomorphism.
 
 \begin{defi}[$\frac{\partial}{\partial x_i}$]\index{$\frac{\partial}{\partial x_i}$}
   Given a chart $\varphi: U \to \R^n$ with $\varphi = (x_1, \cdots, x_n)$, we define
   \[
-    \left.\frac{\partial}{\partial x_i}\right|_p = (D \varphi|_p)^{-1} \left(\left.\frac{\partial}{\partial x_i}\right|_{\varphi(p)}\right) \in T_p M.
+    \left.\frac{\partial}{\partial x_i}\right|_p = (\D \varphi|_p)^{-1} \left(\left.\frac{\partial}{\partial x_i}\right|_{\varphi(p)}\right) \in T_p M.
   \]
 \end{defi}
-So $\left.\frac{\partial}{\partial x_1}\right|_p, \left.\frac{\partial}{\partial x_2}\right|_p, \cdots$ is a basis for $T_p M$.
+So $\left.\frac{\partial}{\partial x_1}\right|_p, \cdots, \left.\frac{\partial}{\partial x_n}\right|_p$ is a basis for $T_p M$.
 
 Recall that if $f: U \to \R$ is smooth, then we can write $f(x_1, \cdots, x_n)$. Then we have
 \[
@@ -494,32 +494,32 @@ Recall that if $f: U \to \R$ is smooth, then we can write $f(x_1, \cdots, x_n)$.
 \]
 So we have a consistent notation.
 
-Now how does this basis change when we change coordinates? Suppose we also have coordinates $y_1, \cdots, y_n$ near $p$ given by some other chart. We then have $\left.\frac{\partial}{\partial y_i}\right|_p \in T_p M$. So we have
+Now, how does this basis change when we change coordinates? Suppose we also have coordinates $y_1, \cdots, y_n$ near $p$ given by some other chart. We then have $\left.\frac{\partial}{\partial y_i}\right|_p \in T_p M$. So we have
 \[
-  \left.\frac{\partial}{\partial y_i}\right|_p = \sum_j \alpha_j \left.\frac{\partial}{\partial x_j}\right|_p
+  \left.\frac{\partial}{\partial y_i}\right|_p = \sum_{j = 1}^n \alpha_j \left.\frac{\partial}{\partial x_j}\right|_p
 \]
 for some $\alpha_j$. To figure out what they are, we apply them to the function $x_k$. So we have
 \[
-  \left.\frac{\partial x_k}{\partial y_i}\right|_p = \alpha_k.
+  \left.\frac{\partial}{\partial y_i}\right|_p (x_k) = \frac{\partial x_k}{\partial y_i}(p) = \alpha_k.
 \]
 So we obtain
 \[
-  \frac{\partial}{\partial y_i} = \sum_j \frac{\partial x_j}{\partial y_i} \frac{\partial}{\partial x_j}.
+  \left.\frac{\partial}{\partial y_i}\right|_p = \sum_{j = 1}^n \frac{\partial x_j}{\partial y_i}(p)\left.\frac{\partial}{\partial x_j}\right|_p.
 \]
 This is the usual change-of-coordinate formula!
 
-Now let $F \in C^\infty(M, N)$, $(U, \varphi)$ be a chart on $M$ containing $p$ with coordinates $x_1, \cdots, x_n$, and $(V, \xi)$ a chart on $N$ containing $q = F(p)$ with coordinates $y_1,\cdots, y_m$. By abuse of notation, we confuse $F$ and $\xi \circ F \circ \varphi^{-1}$. So we write $F = (F_1, \cdots, F_n)$ with $F_i = F_i(x_1, \cdots, x_n): U \to \R$.
+Now let $F \in C^\infty(M, N)$, $(U, \varphi)$ be a chart on $M$ containing $p$ with coordinates $x_1, \cdots, x_n$, and $(V, \xi)$ a chart on $N$ containing $q = F(p)$ with coordinates $y_1,\cdots, y_m$. By abuse of notation, we confuse $F$ and $\xi \circ F \circ \varphi^{-1}$. So we write $F = (F_1, \cdots, F_m)$ with $F_i = F_i(x_1, \cdots, x_n): U \to \R$.
 
 As before, we have a basis
 \begin{align*}
-  \left.\frac{\partial}{\partial x_i}\right|_p, \cdots, \left.\frac{\partial}{\partial x_n}\right|_p&\quad\text{for}\quad T_pM,\\
-  \left.\frac{\partial}{\partial y_i}\right|_q, \cdots, \left.\frac{\partial}{\partial y_m}\right|_q&\quad\text{for}\quad T_qN.
+  \left.\frac{\partial}{\partial x_1}\right|_p, \cdots, \left.\frac{\partial}{\partial x_n}\right|_p&\quad\text{for}\quad T_pM,\\
+  \left.\frac{\partial}{\partial y_1}\right|_q, \cdots, \left.\frac{\partial}{\partial y_m}\right|_q&\quad\text{for}\quad T_qN.
 \end{align*}
 
 \begin{lemma}
   We have
   \[
-    \D F|_p \left(\left.\frac{\partial}{\partial x_i}\right|_p\right) = \sum_{j = 1}^n \frac{\partial F_j}{\partial x_i}(p) \left.\frac{\partial}{\partial y_j}\right|_q.
+    \D F|_p \left(\left.\frac{\partial}{\partial x_i}\right|_p\right) = \sum_{j = 1}^m \frac{\partial F_j}{\partial x_i}(p) \left.\frac{\partial}{\partial y_j}\right|_q.
   \]
   In other words, $\D F|_p$ has matrix representation
   \[
@@ -530,15 +530,15 @@ As before, we have a basis
 \begin{proof}
   We let
   \[
-    \D F|_p \left(\left.\frac{\partial}{\partial x_i}\right|_p\right) = \sum_{j = 1}^n \lambda_j \left.\frac{\partial}{\partial y_j}\right|_q.
+    \D F|_p \left(\left.\frac{\partial}{\partial x_i}\right|_p\right) = \sum_{j = 1}^m \lambda_j \left.\frac{\partial}{\partial y_j}\right|_q.
   \]
-  for some $\lambda_i$. We apply this to the local function $y_k$ to obtain
+  for some $\lambda_j$. We apply this to the local function $y_k$ to obtain
   \begin{align*}
-    \lambda_k &= \left(\sum \lambda_j \left.\frac{\partial}{\partial y_j}\right|_q\right)(y_k)\\
+    \lambda_k &= \left(\sum_{j = 1}^m \lambda_j \left.\frac{\partial}{\partial y_j}\right|_q\right)(y_k)\\
     &= \D F_p \left(\left.\frac{\partial}{\partial x_i}\right|_p\right)(y_k)\\
     &= \left.\frac{\partial}{\partial x_i}\right|_p (y_k \circ F) \\
     &= \left.\frac{\partial}{\partial x_i}\right|_p(F_k) \\
-    &= \frac{\partial F_k}{\partial x_i}(p).
+    &= \frac{\partial F_k}{\partial x_i}(p). \qedhere
   \end{align*}
 \end{proof}
 
@@ -547,7 +547,7 @@ As before, we have a basis
   \[
     \d f|_p(X) = X(f).
   \]
-  (this can, eg, be checked in local coordinates)
+  (this can, e.g., be checked in local coordinates)
 \end{eg}
 
 \subsection{Bump functions and partitions of unity}
@@ -627,13 +627,13 @@ In general, we want a function that looks like this:
   Extending $X$ to be identically $0$ on $M \setminus W$ to get the desired smooth function (up to some constant).
 \end{proof}
 \begin{lemma}
-  Let $p \in W \subseteq U$ and $W, U$ open. Let $f_1, f_2 \in C^\infty(U)$ be such that $f_1 = f_2$ on $W$. Then if $X \in \Der_p(C^\infty(U))$, then we have $X(f_1) = X(f_2)$
+  Let $p \in W \subseteq U$ and $W, U$ open. Let $f_1, f_2 \in C^\infty(U)$ be such that $f_1 = f_2$ on $W$. If $X \in \Der_p(C^\infty(U))$, then we have $X(f_1) = X(f_2)$
 \end{lemma}
 
 \begin{proof}
   Set $h = f_1 - f_2$. We can wlog assume that $W$ is a coordinate chart. We pick a bump function $\chi \in C^\infty(U)$ that vanishes outside $W$. Then $\chi h = 0$. Then we have
   \[
-    0 = X(\chi h) = \chi(p) X(h) + h(p) X(\chi) = X(h) + 0 = X(f_1) - X(f_2).
+    0 = X(\chi h) = \chi(p) X(h) + h(p) X(\chi) = X(h) + 0 = X(f_1) - X(f_2). \qedhere
   \]
 \end{proof}
 
@@ -678,7 +678,7 @@ The important result is the following:
   \]
   Also, by construction, we know $\sum_\alpha \tilde{\varphi}_\alpha > 0$. Finally, we let
   \[
-    \varphi_\alpha = \frac{\tilde{\varphi}\alpha}{\sum_\beta \tilde{\varphi}_\beta}.
+    \varphi_\alpha = \frac{\tilde{\varphi}\alpha}{\sum_\beta \tilde{\varphi}_\beta}. \qedhere
   \]
 \end{proof}
 The general proof will need the fact that the space is second-countable.
@@ -714,26 +714,26 @@ This is a rather technical condition, rather than ``a subset that is also a mani
   \[
     \tilde{\xi} \circ \tilde{\varphi}^{-1} = \pi \circ \xi \circ \varphi^{-1} \circ j,
   \]
-  where $j: \R^k \to \R^n$ is given by $j(x_1, \cdots, x_k) = (x_1, .., x_k, 0, \cdots, 0)$.
+  where $j: \R^k \to \R^n$ is given by $j(x_1, \cdots, x_k) = (x_1, \cdots, x_k, 0, \cdots, 0)$.
 
   From this characterization, by looking at local charts, it is clear that $S$ has the subspace topology. It is then easy to see that the embedded submanifold is Hausdorff and second-countable, since these properties are preserved by taking subspaces.
 
   We can also check easily that $\iota: S \hookrightarrow M$ is smooth, and this is the only differential structure with this property.
 \end{proof}
 
-It is also obvious from the slice charts that
+It is also obvious from the slice charts that:
 \begin{prop}
   Let $S$ be an embedded submanifold. Then the derivative of the inclusion map $\iota: S \hookrightarrow M$ is injective.
 \end{prop}
 
-Sometimes, we like to think of a subobject not as a subset, but as the inclusion map $\iota: S \hookrightarrow M$ instead. However, when we are doing topology, there is this funny problem that a continuous bijection need not be a homeomorphism. So if we define submanifolds via inclusions maps, we get a weaker notion known as an \emph{immersed manifold}.
+Sometimes, we like to think of a subobject not as a subset, but as the inclusion map $\iota: S \hookrightarrow M$ instead. However, when we are doing topology, there is this funny problem that a continuous bijection need not be a homeomorphism. So if we define submanifolds via inclusions maps, we get a weaker notion known as an \emph{immersed submanifold}.
 
 \begin{defi}[Immersed submanifold]\index{immersed submanifold}
-  Let $S, M$ be manifolds, and $\iota: S \hookrightarrow M$ be a smooth injective map with $D\iota|_p : T_p S \to T_p M$ is injective for all $p \in S$. Then we call $(\iota, S)$ an \emph{immersed submanifold}. By abuse, we identify $S$ and $\iota(S)$.
+  Let $S, M$ be manifolds, and $\iota: S \hookrightarrow M$ be a smooth injective map with $\D\iota|_p : T_p S \to T_p M$ injective for all $p \in S$. Then we call $(\iota, S)$ an \emph{immersed submanifold}. By abuse of notation, we identify $S$ and $\iota(S)$.
 \end{defi}
 
 \begin{eg}
-  If we map $\R$ into $\R^2$ via the following figure of eight (where the arrow heads denote the ``end points'' of $\R$), then this gives an immersed manifold that is not an embedded manifold.
+  If we map $\R$ into $\R^2$ via the following figure of eight (where the arrow heads denote the ``end points'' of $\R$), then this gives an immersed submanifold that is not an embedded submanifold.
   \begin{center}
     \begin{tikzpicture}
       \path[use as bounding box] (-1.8, -0.7) rectangle (1.8,0.7);
@@ -765,19 +765,19 @@ More generally, if $M, N$ are manifolds, $F \in C^\infty(M, N)$ and $c \in N$, u
 \begin{proof}
   We let $n = \dim M$ and $m = \dim N$. Notice that for the map $\D F$ to be surjective, we must have $n \geq m$.
 
-  Let $p \in S$, so $F(p) = c$. We want to find a slice coordinate for $S$ near $p$. Since the problem is local, by restricting to local coordinate charts, we may wlog $N = \R^m$, $M = \R^n$ and $c = p = 0$.
+  Let $p \in S$, so $F(p) = c$. We want to find a slice coordinate for $S$ near $p$. Since the problem is local, by restricting to local coordinate charts, we may wlog assume $N = \R^m$, $M = \R^n$ and $c = p = 0$.
 
   Thus, we have a smooth map $F: \R^n \to \R^m$ with surjective derivative at $0$. Then the derivative is
   \[
-    \left(\left.\frac{\partial F_j}{\partial x_i}\right|\right)_{i = 1, \ldots, n; j = 1, \ldots, m},
+    \left(\left.\frac{\partial F_j}{\partial x_i}\right|_0\right)_{i = 1, \ldots, n; \, j = 1, \ldots, m},
   \]
   which by assumption has rank $m$. We reorder the $x_i$ so that the first $m$ columns are independent. Then the $m \times m$ matrix
   \[
-    R = \left(\left.\frac{\partial F_j}{\partial x_i}\right|\right)_{i,j = 1, \ldots, m}
+    R = \left(\left.\frac{\partial F_j}{\partial x_i}\right|_0\right)_{i,j = 1, \ldots, m}
   \]
   is non-singular. We consider the map
   \[
-    \alpha(x_1, \cdots, x_n) = (F_1, \cdots, F_m, x_{m + 1}, x_{m + 2}, \cdots, x_n).
+    \alpha(x_1, \cdots, x_n) = (F_1, \cdots, F_m, x_{m + 1}, \cdots, x_n).
   \]
   We then obtain
   \[
@@ -789,7 +789,7 @@ More generally, if $M, N$ are manifolds, $F \in C^\infty(M, N)$ and $c \in N$, u
   \]
   and this is non-singular. By the inverse function theorem, $\alpha$ is a local diffeomorphism. So there is an open $W\subseteq \R^n$ containing $0$ such that $\alpha|_W: W \to \alpha(W)$ is smooth with smooth inverse. We claim that $\alpha$ is a slice chart of $S$ in $\R^n$.
 
-  Since it is a smooth diffeomorphism, it is certainly a chart. Moreover, by construction, the points in $S$ are exactly those whose image under $F$ have the first $n$ coordinates vanish. So this is the desired slice chart.
+  Since it is a smooth diffeomorphism, it is certainly a chart. Moreover, by construction, the points in $S$ are exactly those whose image under $F$ have the first $m$ coordinates vanish. So this is the desired slice chart.
 \end{proof}
 
 \begin{eg}
@@ -799,7 +799,7 @@ More generally, if $M, N$ are manifolds, $F \in C^\infty(M, N)$ and $c \in N$, u
   \]
   Then $F^{-1}(1) = S^n$. We find that
   \[
-    \D F|_p = 2(x_0, \cdots, x_{n + 1}) \not= 0
+    \D F|_p = 2(x_0, \cdots, x_n) \not= 0
   \]
   when $p \in S^n$. So $S^n$ is a manifold.
 \end{eg}
@@ -869,7 +869,7 @@ Assuming that we have successfully constructed a sensible $TM$, we can define:
 
   Moreover, if $V \subseteq U \subseteq M$ and $X \in \Vect(U)$, then $X|_V \in \Vect(V)$.
 
-  Conversely, if $\{V_i\}$ is a cover of $U$, and $X_i \in V_i$ are such that they agree on intersections, then they patch together to give an element of $\Vect(U)$. So we say that $\Vect$ is a \emph{sheaf of $C^\infty(M)$ modules}.
+  Conversely, if $\{V_i\}$ is a cover of $U$, and $X_i \in \Vect(V_i)$ are such that they agree on intersections, then they patch together to give an element of $\Vect(U)$. So we say that $\Vect$ is a \emph{sheaf of $C^\infty(M)$ modules}.
 \end{defi}
 
 Now we properly define the manifold structure on the tangent bundle.
@@ -881,7 +881,7 @@ Now we properly define the manifold structure on the tangent bundle.
   \]
   There is a natural projection map $\pi: TM \to M$ sending $v_p \in T_pM$ to $p$.
 
-  Let $x_1, \cdots, x_n$ be coordinates on a chart $(U, \varphi)$. Then for any $p \in U$ and $v_p \in T_p M$, there is some $\alpha_1, \cdots, \alpha_n \in \R$ such that
+  Let $x_1, \cdots, x_n$ be coordinates on a chart $(U, \varphi)$. Then for any $p \in U$ and $v_p \in T_p M$, there are some $\alpha_1, \cdots, \alpha_n \in \R$ such that
   \[
     v_p = \sum_{i = 1}^n \alpha_i \left.\frac{\partial}{\partial x_i}\right|_{p}.
   \]
@@ -898,13 +898,13 @@ Now we properly define the manifold structure on the tangent bundle.
 \end{lemma}
 
 \begin{proof}
-  If $(V, \xi)$ is another chart on $M$ with coordinates $y_1, \cdots, y_m$, then
+  If $(V, \xi)$ is another chart on $M$ with coordinates $y_1, \cdots, y_n$, then
   \[
-    \left.\frac{\partial}{\partial x_i}\right|_p = \sum_j \frac{\partial y_j}{\partial x_i}(p) \left.\frac{\partial}{\partial y_j}\right|_p.
+    \left.\frac{\partial}{\partial x_i}\right|_p = \sum_{j = 1}^n \frac{\partial y_j}{\partial x_i}(p) \left.\frac{\partial}{\partial y_j}\right|_p.
   \]
   So we have $\tilde{\xi} \circ \tilde{\varphi}^{-1}: \varphi(U \cap V) \times \R^n \to \xi(U \cap V) \times \R^n$ given by
   \[
-    \tilde{\xi} \circ \tilde{\varphi}^{-1} (x_1, \cdots, x_n, \alpha_1, \cdots, \alpha_n) = \left(y_1, \cdots, y_n, \sum_i \alpha_i \frac{\partial y_{1}}{\partial x_i}, \cdots, \sum \alpha_i \frac{\partial y_n}{\partial x_i}\right),
+    \tilde{\xi} \circ \tilde{\varphi}^{-1} (x_1, \cdots, x_n, \alpha_1, \cdots, \alpha_n) = \left(y_1, \cdots, y_n, \sum_{i = 1}^n \alpha_i \frac{\partial y_{1}}{\partial x_i}, \cdots, \sum_{i = 1}^n \alpha_i \frac{\partial y_n}{\partial x_i}\right),
   \]
   and is smooth (and in fact fiberwise linear).
 
@@ -920,7 +920,7 @@ There are a few remarks to make about this.
     \]
     We write $X_p$ for $X(p)$. Now suppose further that $U$ is a coordinate chart, then we can write any function $X: U \to T_p M$ such that $X_p \in T_p M$ (uniquely) as
     \[
-      X_p = \sum_i \alpha_i(p) \left.\frac{\partial}{\partial x_i} \right|_p
+      X_p = \sum_{i = 1}^n \alpha_i(p) \left.\frac{\partial}{\partial x_i} \right|_p
     \]
     Then $X$ is smooth iff all $\alpha_i$ are smooth.
   \item If $F \in C^\infty(M, N)$, then $\D F: TM \to TN$ given by $\D F(v_p) = \D F|_p(v_p)$ is smooth. This is nice, since we can easily talk about higher derivatives, by taking the derivative of the derivative map.
@@ -974,7 +974,7 @@ It is an exercise to show that $\mathcal{X}(f)$ is smooth and satisfies the Leib
   \]
   So $X_p \in T_p M$. We just need to check that the map $M \to TM$ sending $p \mapsto X_p$ is smooth. Locally on $M$, we have coordinates $x_1, \cdots, x_n$, and we can write
   \[
-    X_p = \sum \alpha_i(p) \left.\frac{\partial}{\partial x_i}\right|_p.
+    X_p = \sum_{i = 1}^n \alpha_i(p) \left.\frac{\partial}{\partial x_i}\right|_p.
   \]
   We want to show that $\alpha_i: U \to \R$ are smooth.
 
@@ -989,9 +989,9 @@ It is an exercise to show that $\mathcal{X}(f)$ is smooth and satisfies the Leib
   So $\alpha_j$ is smooth.
 \end{proof}
 
-From now on, we confuse $X$ and $\mathcal{X}$, ie. we think of any $X \in \Vect(M)$ as a derivation of $C^\infty(M)$.
+From now on, we confuse $X$ and $\mathcal{X}$, i.e.\ we think of any $X \in \Vect(M)$ as a derivation of $C^\infty(M)$.
 
-Note that the product of two vector fields (ie. the composition of derivations) is not a vector field. We can compute
+Note that the product of two vector fields (i.e.\ the composition of derivations) is not a vector field. We can compute
 \begin{align*}
   XY(fg) &= X(Y(fg)) \\
   &= X(fY(g) + gY(f)) \\
@@ -1007,7 +1007,7 @@ So $\Vect(M)$ becomes what is known as a \emph{Lie algebra}.
   A \emph{Lie algebra} is a vector space $V$ with a bracket $[\ph, \ph]: V \times V \to V$ such that
   \begin{enumerate}
     \item $[\ph, \ph]$ is bilinear.
-    \item $[\ph, \ph]$ is antisymmetric, ie. $[X, Y] = -[Y, X]$.
+    \item $[\ph, \ph]$ is antisymmetric, i.e.\ $[X, Y] = -[Y, X]$.
     \item The \term{Jacobi identity} holds
       \[
         [X, [Y, Z]] + [Y, [Z, X]] + [Z, [X, Y]] = 0.
@@ -1057,7 +1057,7 @@ What can we do with vector fields? In physics, we can imagine a manifold as all 
   \]
   So the equation is
   \begin{align*}
-    \gamma_1'(t) &= \gamma_2(t)\\
+    \gamma_1'(t) &= - \gamma_2(t)\\
     \gamma_2'(t) &= \gamma_1(t).
   \end{align*}
   For example, if our starting point is $p = (1, 0)$, then we have
@@ -1072,7 +1072,7 @@ We see that to find an integral curve, all we are doing is just solving ordinary
   \[
     X = x^2 \frac{\d}{\d x}.
   \]
-  Then if $\gamma$ is an integral curve, then
+  Then if $\gamma$ is an integral curve, it must satisfy:
   \[
     \gamma'(t) = \gamma(t)^2.
   \]
@@ -1112,11 +1112,11 @@ We are going to prove that integral curves always exist. To do so, we need to bo
 \begin{proof}
   Pick local coordinates for $M$ centered at $p$ in an open neighbourhood $U$. So locally we write
   \[
-    X = \sum \alpha_i \frac{\partial}{\partial x_i},
+    X = \sum_{i = 1}^n \alpha_i \frac{\partial}{\partial x_i},
   \]
   where $\alpha_i \in C^\infty(U)$. We want to find $\gamma = (\gamma_1, \cdots, \gamma_n): I \to U$ such that
   \[
-    \sum_i \gamma_i'(t) \left.\frac{\partial}{\partial x_i}\right|_{\gamma(t)} = \sum_i \alpha_i(\gamma(t)) \left.\frac{\partial}{\partial x_i}\right|_{\gamma(t)},\quad \gamma_i(0) = 0.
+    \sum_{i = 1}^n \gamma_i'(t) \left.\frac{\partial}{\partial x_i}\right|_{\gamma(t)} = \sum_{i = 1}^n \alpha_i(\gamma(t)) \left.\frac{\partial}{\partial x_i}\right|_{\gamma(t)},\quad \gamma_i(0) = 0.
   \]
   Since the $\frac{\partial}{\partial x_i}$ form a basis, this is equivalent to saying
   \[
@@ -1128,7 +1128,7 @@ We are going to prove that integral curves always exist. To do so, we need to bo
 
   However, we need to do a bit more for uniqueness, since all we know is that there is a unique integral curve lying in this particular chart. It might be that there are integral curves that do wild things when they leave the chart.
 
-  So suppose $\gamma: I \to M$ and $\tilde{\gamma}: \tilde{I} \to M$ are both integral curves passing through the same point, ie. $\gamma(0) = \tilde{\gamma}(0) = p$.
+  So suppose $\gamma: I \to M$ and $\tilde{\gamma}: \tilde{I} \to M$ are both integral curves passing through the same point, i.e.\ $\gamma(0) = \tilde{\gamma}(0) = p$.
 
   We let
   \[
@@ -1268,7 +1268,7 @@ We now define the \emph{Lie derivative} of a function, ie. the derivative of a f
     \mathcal{L}_X(g)(p) &= \left.\frac{\d}{\d t}\right|_{t = 0} \Theta_t^*(g)(p) \\
     &= \left.\frac{\d}{\d t}\right|_{t = 0} g(\Theta_t(p)) \\
     &= \d g|_p(X(p))\\
-    &= X(g)(p).
+    &= X(g)(p). \qedhere
   \end{align*}
 \end{proof}
 
@@ -1572,7 +1572,7 @@ So in the case of $G = \GL_n$, the exponential map is the exponential map.
         \D \exp|_0 (\xi) = \D \exp|_0(\dot{\sigma}(0)) = \left.\frac{\d}{\d t}\right|_{t = 0} \exp(\sigma(t)) = \left.\frac{\d}{\d t}\right|_{t = 0} \exp(t \xi) = X_\xi|_e = \xi.
       \]
     \item Follows from above by inverse function theorem.
-    \item Exercise.
+    \item Exercise. \qedhere
   \end{enumerate}
 \end{proof}
 
@@ -1605,7 +1605,7 @@ The tensor product is a very important concept in Linear Algebra. It is somethin
 A motivation for tensors comes from the study of bilinear maps. A bilinear map is a function that takes in two vectors and returns a number, and this is linear in both variables. An example is the inner product, and another example is the volume form, which tells us the volume of a parallelepiped spanned by the two vectors.
 
 \begin{defi}[Bilinear map]\index{bilinear map}
-  Let $U, V, W$ be vector spaces. We define $\Bilin(V\times W, U)$ to be the functions $V \times W \to U$ that are bilinear, ie.
+  Let $U, V, W$ be vector spaces. We define $\Bilin(V\times W, U)$ to be the functions $V \times W \to U$ that are bilinear, i.e.\
   \begin{align*}
     \alpha(\lambda_1 v_1 + \lambda_2 v_2, w) &= \lambda_1 \alpha(v_1, w) + \lambda_2 \alpha(v_2, w)\\
     \alpha(v, \lambda_1 w_1 + \lambda_2 w_2) &= \lambda_1 \alpha(v, w_1) + \lambda_2 \alpha(v, w_2).
@@ -1705,9 +1705,9 @@ We now write down some basic properties of tensor products.
 \end{defi}
 
 \begin{eg}
-  A covariant $1$-tensor is an $\alpha \in V^*$, ie. a linear map $\alpha: V \to \R$.
+  A covariant $1$-tensor is an $\alpha \in V^*$, i.e.\ a linear map $\alpha: V \to \R$.
 
-  A covariant $2$-tensor is a $\beta \in V^* \otimes V^*$, ie. a bilinear map $V \times V \to \R$, eg. an inner product.
+  A covariant $2$-tensor is a $\beta \in V^* \otimes V^*$, i.e.\ a bilinear map $V \times V \to \R$, e.g.\ an inner product.
 \end{eg}
 
 \begin{eg}
@@ -1724,7 +1724,7 @@ We now write down some basic properties of tensor products.
     T^k_\ell(V) = \underbrace{V^* \otimes \cdots \otimes V^*}_{k\text{ times}} \otimes \underbrace{V \otimes \cdots \otimes V}_{\ell\text{ times}}.
   \]
 \end{defi}
-We are interested in alternating bilinear maps, ie. $\alpha(v, w) = - \alpha(w, v)$, or equivalently, $\alpha(v, v) = 0$ (if the characteristic is not $2$).
+We are interested in alternating bilinear maps, i.e.\ $\alpha(v, w) = - \alpha(w, v)$, or equivalently, $\alpha(v, v) = 0$ (if the characteristic is not $2$).
 
 \begin{defi}[Exterior product]\index{exterior product}\index{exterior algebra}
   Consider
@@ -1793,7 +1793,7 @@ The idea is that $\Lambda^p V$ is the dual of the space of alternating multiline
       \[
         \sum_{I'} \alpha_{I'} v_{I'} \wedge v_J = a_I v_I \wedge v_J = 0.
       \]
-      So $a_I = 0$. So done by (ii).
+      So $a_I = 0$. So done by (ii). \qedhere
   \end{enumerate}
 \end{proof}
 
@@ -1813,7 +1813,7 @@ More concretely, we have
 \end{lemma}
 
 \begin{proof}
-  Let $v_1, \cdots, v_n$ be a basis. Then $\Lambda^n V$ is spanned by $v_1 \wedge \cdots \wedge v_n$ So we have
+  Let $v_1, \cdots, v_n$ be a basis. Then $\Lambda^n V$ is spanned by $v_1 \wedge \cdots \wedge v_n$. So we have
   \[
     (\Lambda^n F)(v_1\wedge \cdots \wedge v_n) = \lambda v_1 \wedge \cdots \wedge v_n
   \]
@@ -1821,7 +1821,7 @@ More concretely, we have
   \[
     F(v_i) = \sum_j A_{ji} v_j
   \]
-  for some $A_{ji} \in \R$, ie. $A$ is the matrix representation of $F$. Then we have
+  for some $A_{ji} \in \R$, i.e.\ $A$ is the matrix representation of $F$. Then we have
   \[
     (\Lambda^n F)(v_1 \wedge \cdots \wedge v_n) = \biggl(\sum_j A_{j1} v_j\biggr) \wedge \cdots \wedge \biggl(\sum_j A_{jn} v_j\biggr).
   \]
@@ -1833,7 +1833,7 @@ More concretely, we have
 \end{proof}
 
 \subsection{Vector bundles}
-Our aim is to consider spaces $T_p M \otimes T_p M, \ldots, \Lambda^r T_p M$ etc as $p$ varies, ie. construct a ``tensor bundle'' for these tensor products, similar to how we constructed the tangent bundle. Thus, we need to come up with a general notion of vector bundle.
+Our aim is to consider spaces $T_p M \otimes T_p M, \ldots, \Lambda^r T_p M$ etc as $p$ varies, i.e.\ construct a ``tensor bundle'' for these tensor products, similar to how we constructed the tangent bundle. Thus, we need to come up with a general notion of vector bundle.
 
 \begin{defi}[Vector bundle]\index{vector bundle}
   A \emph{vector bundle} of rank $r$ on $M$ is a smooth manifold $E$ with a smooth $\pi: E \to M$ such that
@@ -2043,7 +2043,7 @@ where the $\alpha$ are smooth functions.
 \end{eg}
 
 \begin{defi}[Riemannian metric]\index{Riemannian metric}
-  A \emph{Riemannian metric} on $M$ is a $(2, 0)$-tensor $g$ such that for all $p$, the bilinear map $g_p: T M \times T M \to \R$ is symmetric and positive definite, ie. an inner product.
+  A \emph{Riemannian metric} on $M$ is a $(2, 0)$-tensor $g$ such that for all $p$, the bilinear map $g_p: T M \times T M \to \R$ is symmetric and positive definite, i.e.\ an inner product.
 
   Given such a $g$ and $v_p \in T_p M$, we write $\norm{v_p}$ for $\sqrt{g(v_p, v_p)}$.
 \end{defi}


### PR DESCRIPTION
Corrected a few more typos and tried to make notation more consistent in some places. I haven't made any significant alterations of the text.

As for (minor) typographical suggestions, ie. and eg. should by typed as i.e. and e.g. being abbreviations of "exampli gratia" and "id est", which mean roughly "example given" and "that is". I have corrected some of these.
Moreover, in LaTeX they should be immediately followed by a backslash, otherwise LaTeX will interpret the last dot as the end of the sentence and put too much space afterwards. Not that anyone would note or care, but as long as we know it, we might as well do it.

Two more absolutely inessential (but nice to know, imho) things: 1) for function definitions one should use "\colon" instead of ":" since this ":" is interpreted as a binary operator and has the same spacing on both sides. It is ok, for example, to use it in set definitions or for ratios etc.
2) The choice of \ldots vs \cdots should be dictated by "alignment" considerations. For example, between two commas \ldots looks better than \cdots since the commas align with \ldots, while between "centered" operators \cdots looks better. For example A_1 \to \cdots \to A_n.
But I haven't changed any of this in the notes, it's not that crucial.

Sorry for the long message, I hope I didn't bore you too much. I just wanted to thank you for all the time and effort you put into these notes. They have been very useful to me.

Simon