### PR TITLE
typos and suggestions

### DIFF
--- a/III_M/quantum_field_theory.tex
+++ b/III_M/quantum_field_theory.tex
@@ -2527,7 +2527,7 @@ These amplitudes can be further related to experimentally measurable quantities.
 \]
 where
 \[
-  \d \rho_f = (2\pi)^4 \delta^{(4)}(p_F - p_I) \prod_r \frac{\d^3 p_r}{(2\pi)^3 2 p_r^0},
+  \d \rho_f = (2\pi)^4 \delta^4(p_F - p_I) \prod_r \frac{\d^3 p_r}{(2\pi)^3 2 p_r^0},
 \]
 and $r$ runs over all momenta in the final states.
 

--- a/III_M/quantum_field_theory.tex
+++ b/III_M/quantum_field_theory.tex
@@ -378,7 +378,7 @@ We can have a slight generalization where we relax the condition for a symmetry 
 \[
   j^\mu = \frac{\partial \mathcal{L}}{\partial (\partial_\mu \phi_a)} X_a - F^\mu.
 \]
-\begin{eg}[Space-time]
+\begin{eg}[Space-time invariance]
   Recall that in classical dynamics, spatial invariance implies the conservation of momentum, and invariance wrt to time translation implies the conservation of energy. We'll see something similar in field theory. Consider $x^\mu \mapsto x^\mu - \varepsilon^\mu$. Then we obtain
   \[
     \phi_a(x) \mapsto \phi_a(x) + \varepsilon^\nu \partial_\nu \phi_a(x).
@@ -429,7 +429,7 @@ In this example, $T^{\mu\nu}$ comes out symmetric in $\mu$ and $\nu$. In general
 \]
 with $\Gamma^{\rho\mu\nu}$ a tensor antisymmetric in $\rho$ and $\mu$. Then we have
 \[
-  \partial_\mu \partial_\rho T^{\rho\mu\nu} = 0.
+  \partial_\mu \partial_\rho \Gamma^{\rho\mu\nu} = 0.
 \]
 So this $\sigma^{\mu\nu}$ is also invariant.
 
@@ -438,9 +438,9 @@ A symmetric energy-momentum tensor of this form is actually useful, and is found
 \begin{eg}[Internal symmetries]
   Consider a complex scalar field
   \[
-    \psi(x) = \frac{1}{\sqrt{2}} (\phi_1 + i \phi_2).
+    \psi(x) = \frac{1}{\sqrt{2}} (\phi_1(x) + i \phi_2(x)),
   \]
-  We put
+  where $\phi_1$ and $\phi_2$ are real scalar fields. We put
   \[
     \mathcal{L} = \partial_\mu \psi^* \partial^\mu \psi - V(\psi^*\psi),
   \]
@@ -452,8 +452,9 @@ A symmetric energy-momentum tensor of this form is actually useful, and is found
 
   To find the equations of motion, if we do all the complex analysis required, we will figure that we will obtain the same equations as the real case if we treat $\psi$ and $\psi^*$ as independent variables. In this case, we obtain
   \[
-    \partial_\mu \partial^\mu \psi + m^2 \psi + \lambda (\psi^*\psi) \psi + \cdots = 0.
+    \partial_\mu \partial^\mu \psi + m^2 \psi + \lambda (\psi^*\psi) \psi + \cdots = 0
   \]
+  and its complex conjugate.
   The $\mathcal{L}$ has a symmetry given by $\psi \mapsto e^{i\alpha} \psi$. Infinitesimally, we have $\delta \psi = i\alpha \psi$, and $\delta \psi^* = -i\alpha \psi^*$.
 
   This gives a current
@@ -503,7 +504,7 @@ This is not to be confused with the total momentum $\mathbf{P}_i$.
   \[
     \mathcal{H} = \pi(x) \dot{\phi}(x) - \mathcal{L}(x),
   \]
-  where we replace all occurrences of $\dot{\phi}$ by expressing it in terms of $\pi(x)$.
+  where we replace all occurrences of $\dot{\phi}(x)$ by expressing it in terms of $\pi(x)$.
 \end{defi}
 
 \begin{eg}
@@ -524,7 +525,7 @@ This is not to be confused with the total momentum $\mathbf{P}_i$.
 \begin{defi}[Hamiltonian]\index{Hamiltonian}
   The \emph{Hamiltonian} of a Hamiltonian system is
   \[
-    H = \int\;\d^3 x\; \mathcal{H}.
+    H = \int\;\d^3 \mathbf{x}\; \mathcal{H}.
   \]
 \end{defi}
 This agrees with the field energy we computed using Noether's theorem.
@@ -631,7 +632,7 @@ We can invert these to find
 \[
   q = \frac{1}{\sqrt{2\omega}}(a + a^\dagger),\quad p = -i\sqrt{\frac{\omega}{2}} (a - a^\dagger).
 \]
-We can substitute these equations into the commutator relations to obtain
+We can substitute these equations into the commutator relation to obtain
 \[
   [a, a^\dagger] = 1.
 \]
@@ -700,7 +701,7 @@ We are now going to use canonical quantization to promote our classical fields t
   \]
 \end{defi}
 
-The evolution of states is again given by Schr\"odinger equations.
+The evolution of states is again given by Schr\"odinger equation.
 \begin{defi}[Schr\"odinger equation]\index{Schr\"odinger equation}
   The \emph{Schr\"odinger equation} says
   \[
@@ -796,7 +797,11 @@ We are now going to find the commutation relations for the $a_\mathbf{p}$ and $a
     ={}& \frac{(-i)}{2} \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \left(-e^{-i\mathbf{p}\cdot (\mathbf{x} - \mathbf{y})} - e^{i\mathbf{p} \cdot(\mathbf{y} - \mathbf{x})}\right)\\
     ={}& i \delta^3(\mathbf{x} - \mathbf{y}).
   \end{align*}
-  Note that to prove the inverse direction, we have to invert the relation between $\phi(\mathbf{x}), \pi(\mathbf{x})$ and $a_\mathbf{p}, a_\mathbf{p}^\dagger$ and express $a_\mathbf{p}$ and $a_\mathbf{p}^\dagger$ in terms of $\phi$ and $\pi$.
+  Note that to prove the inverse direction, we have to invert the relation between $\phi(\mathbf{x}), \pi(\mathbf{x})$ and $a_\mathbf{p}, a_\mathbf{p}^\dagger$ and express $a_\mathbf{p}$ and $a_\mathbf{p}^\dagger$ in terms of $\phi$ and $\pi$ by using
+\begin{align*}
+ \int \d^3 \mathbf{x} \; \phi(\mathbf{x}) \, e^{i \mathbf{p} \cdot \mathbf{x}} &= \frac{1}{\sqrt{2 \omega_\mathbf{p}}} \left(a_{-\mathbf{p}}  + a_\mathbf{p}^\dagger  \right)\\
+ \int \d^3 \mathbf{x} \; \pi(\mathbf{x}) \, e^{i \mathbf{p} \cdot \mathbf{x}} &= (-i) \sqrt{\frac{\omega_\mathbf{p}}{2}}\left(a_{-\mathbf{p}} - a_\mathbf{p}^\dagger  \right). \qedhere
+\end{align*}
 \end{proof}
 So our creation and annihilation operators do satisfy commutation relations similar to the case of a simple harmonic oscillator.
 
@@ -817,8 +822,8 @@ For the sake of sanity, we will evaluate this piece by piece. We have
   \int \d^3 \mathbf{x}\;\pi^2 &=- \int \frac{\d^3 \mathbf{x}\;\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^6} \frac{\sqrt{\omega_\mathbf{p} \omega_\mathbf{q}}}{2} (a_\mathbf{p} e^{i\mathbf{p}\cdot \mathbf{x}} - a_\mathbf{p}^{\dagger} e^{-i\mathbf{p}\cdot \mathbf{x}})(a_\mathbf{q} e^{i\mathbf{q}\cdot \mathbf{x}} - a_\mathbf{q}^{\dagger} e^{-i\mathbf{q}\cdot \mathbf{x}})\\
   &=- \int \frac{\d^3 \mathbf{x}\;\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^6} \frac{\sqrt{\omega_\mathbf{p} \omega_\mathbf{q}}}{2} (a_\mathbf{p} a_\mathbf{q}e^{i(\mathbf{p} + \mathbf{q})\cdot \mathbf{x}} - a_\mathbf{p}^\dagger a_\mathbf{q} e^{i(\mathbf{q} - \mathbf{p})\cdot \mathbf{x}} \\
   &\hphantom{=- \int \frac{\d^3 \mathbf{x}\;\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^6} \frac{\sqrt{\omega_\mathbf{p} \omega_\mathbf{q}}}{2} (}- a_\mathbf{p}a_\mathbf{q}^\dagger e^{i(\mathbf{p} - \mathbf{q})\cdot \mathbf{x}} + a_\mathbf{p}^\dagger a_\mathbf{q}^\dagger e^{-i(\mathbf{p} + \mathbf{q})\cdot \mathbf{x}})\\
-  &=- \int \frac{\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^3} \frac{\sqrt{\omega_\mathbf{p} \omega_\mathbf{q}}}{2} (a_\mathbf{p} a_\mathbf{q} \delta(\mathbf{p} + \mathbf{q}) - a_\mathbf{p}^\dagger a_\mathbf{q} \delta(\mathbf{p} - \mathbf{q})\\
-  &\hphantom{=-\int \frac{\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^3} \frac{\sqrt{\omega_\mathbf{p} \omega_\mathbf{q}}}{2} (}-a_\mathbf{p} a_\mathbf{q}^\dagger \delta(\mathbf{p} - \mathbf{q}) + a_\mathbf{p}^\dagger a_\mathbf{q}^\dagger \delta(\mathbf{p} + \mathbf{q}))\\
+  &=- \int \frac{\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^3} \frac{\sqrt{\omega_\mathbf{p} \omega_\mathbf{q}}}{2} (a_\mathbf{p} a_\mathbf{q} \delta^3(\mathbf{p} + \mathbf{q}) - a_\mathbf{p}^\dagger a_\mathbf{q} \delta^3(\mathbf{p} - \mathbf{q})\\
+  &\hphantom{=-\int \frac{\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^3} \frac{\sqrt{\omega_\mathbf{p} \omega_\mathbf{q}}}{2} (}-a_\mathbf{p} a_\mathbf{q}^\dagger \delta^3(\mathbf{p} - \mathbf{q}) + a_\mathbf{p}^\dagger a_\mathbf{q}^\dagger \delta^3(\mathbf{p} + \mathbf{q}))\\
   &=\int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{\omega_\mathbf{p}}{2} ((a_\mathbf{p}^\dagger a_\mathbf{p} + a_\mathbf{p} a_\mathbf{p}^\dagger) - (a_\mathbf{p} a_{-\mathbf{p}} + a_\mathbf{p}^\dagger a_{-\mathbf{p}}^\dagger)).
 \end{align*}
 That was tedious. We similarly compute
@@ -877,7 +882,7 @@ Under this assumption, we would want to cut off the integral at high momentum in
 
 Even more straightforwardly, if we just care about energy differences, we can just forget about the infinite term, and write
 \[
-  H = \int \frac{\d^3 p}{(2\pi)^3} \omega_\mathbf{p} a_\mathbf{p}^\dagger a_\mathbf{p}.
+  H = \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \omega_\mathbf{p} a_\mathbf{p}^\dagger a_\mathbf{p}.
 \]
 Then we have
 \[
@@ -899,7 +904,7 @@ It is convenient to have the following notion:
   \[
     \phi_1(\mathbf{x}_1) \cdots \phi_n(\mathbf{x}_n),
   \]
-  the \emph{normal order} is what you obtain when you put all the annihilation operators in the RHS. This is written as
+  the \emph{normal order} is what you obtain when you put all the annihilation operators to the right of (i.e.\ acting before) all the creation operators. This is written as
   \[
     \normalorder{\phi_1(\mathbf{x}_1) \cdots \phi_n(\mathbf{x}_n)}.
   \]
@@ -996,7 +1001,7 @@ We called the operators $a_\mathbf{p}$ and $a_\mathbf{p}^\dagger$ the creation a
 Then we can compute
 \begin{align*}
   [H, a_\mathbf{p}^\dagger] &= \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \omega_\mathbf{q} [a_\mathbf{q}^\dagger a_\mathbf{q}, a_\mathbf{p}^\dagger]\\
-  &= \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \omega_\mathbf{q} a_\mathbf{q}^\dagger (2\pi)^3 \delta(\mathbf{p} - \mathbf{q})\\
+  &= \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \omega_\mathbf{q} a_\mathbf{q}^\dagger (2\pi)^3 \delta^3(\mathbf{p} - \mathbf{q})\\
   &= \omega_\mathbf{p} a_\mathbf{p}^\dagger.
 \end{align*}
 Similarly, we obtain
@@ -1023,12 +1028,12 @@ So we interpret $\bket{\mathbf{p}}$ as the momentum eigenstate of a particle of 
 
 Let's check this interpretation. After normal ordering, we have
 \[
-  \mathbf{P} = \int \pi(x) \nabla \phi(\mathbf{x}) \;\d^3 \mathbf{x} = \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \mathbf{p} a_\mathbf{p}^\dagger a_\mathbf{p}.
+  \mathbf{P} = \int \pi(\mathbf{x}) \nabla \phi(\mathbf{x}) \;\d^3 \mathbf{x} = \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \mathbf{p} a_\mathbf{p}^\dagger a_\mathbf{p}.
 \]
 So we have
 \begin{align*}
   \mathbf{P}\bket{\mathbf{p}} &= \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \mathbf{q} a_\mathbf{q}^\dagger a_\mathbf{q}(a_\mathbf{p}^\dagger \bket{0})\\
-  &= \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \mathbf{q} a_\mathbf{q}^\dagger (a_\mathbf{p}^\dagger a_\mathbf{q} + (2\pi)^3 \delta(\mathbf{p} - \mathbf{q}))\bket{0}\\
+  &= \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \mathbf{q} a_\mathbf{q}^\dagger (a_\mathbf{p}^\dagger a_\mathbf{q} + (2\pi)^3 \delta^3(\mathbf{p} - \mathbf{q}))\bket{0}\\
   &= \mathbf{p}a_\mathbf{p}^\dagger \bket{0}\\
   &= \mathbf{p}\bket{\mathbf{p}}.
 \end{align*}
@@ -1046,7 +1051,7 @@ So the state has total momentum $\mathbf{p}$.
 
 What about multi-particle states? We just have to act with more $a_\mathbf{p}^\dagger$'s. We have the $n$-particle state
 \[
-  \bket{\mathbf{p}_1, \cdots, \mathbf{p}_n} = a_{\mathbf{p}_1}^\dagger a_{\mathbf{p}_2}^\dagger \cdots a_{\mathbf{p}_n}^\dagger \bket{0}.
+  \bket{\mathbf{p}_1, \mathbf{p}_2, \cdots, \mathbf{p}_n} = a_{\mathbf{p}_1}^\dagger a_{\mathbf{p}_2}^\dagger \cdots a_{\mathbf{p}_n}^\dagger \bket{0}.
 \]
 Note that $\bket{\mathbf{p}, \mathbf{q}} = \bket{\mathbf{q}, \mathbf{p}}$ for any $\mathbf{p}, \mathbf{q}$. So any two parts are symmetric under interchange, i.e.\ they are \term{bosons}.
 
@@ -1125,7 +1130,7 @@ Our first example would be the following:
 \begin{proof}
   We know $\int \d^4 p$ certainly is Lorentz invariant, and
   \[
-    |p|^2 = p_0^2 - \mathbf{p}^2
+    m^2 = p_\mu p^\mu = p^2 = p_0^2 - \mathbf{p}^2
   \]
   is also a Lorentz-invariant quantity. So for any $m$, the expression
    \[
@@ -1175,7 +1180,7 @@ We can now define relativistically normalized creation operators by
 \]
 Then we can write our field as
 \[
-  \phi = \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}\frac{1}{2E_\mathbf{p}} e^{i\mathbf{p}\cdot \mathbf{x}}(a^\dagger(p) + a(p)).
+  \phi (\mathbf{x}) = \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}\frac{1}{2E_\mathbf{p}} e^{i\mathbf{p}\cdot \mathbf{x}}(a^\dagger(p) + a(p)).
 \]
 \subsection{Complex scalar fields}
 What happens when we want to talk about a complex scalar field? A classical free complex scalar field would have Lagrangian
@@ -1184,17 +1189,17 @@ What happens when we want to talk about a complex scalar field? A classical free
 \]
 Again, we want to write the quantized $\psi$ as an integral of annihilation and creation operators indexed by momentum. In the case of a real scalar field, we had the expression
 \[
-  \phi(\mathbf{x}) = \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{\sqrt{2 \omega_\mathbf{p}}} \left(a_\mathbf{p} e^{i \mathbf{p} \cdot \mathbf{x}} + a_\mathbf{p}^\dagger e^{-i \mathbf{p}\cdot \mathbf{x}}\right)
+  \phi(\mathbf{x}) = \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{\sqrt{2 E_\mathbf{p}}} \left(a_\mathbf{p} e^{i \mathbf{p} \cdot \mathbf{x}} + a_\mathbf{p}^\dagger e^{-i \mathbf{p}\cdot \mathbf{x}}\right)
 \]
-We needed the ``coefficients'' of $e^{i\mathbf{p}\cdot \mathbf{x}}$ and those of $e^{-i\mathbf{p}\cdot \mathbf{x}}$ to be $a_\mathbf{p}$ and its conjugate $a_\mathbf{p}^\dagger$ so that the resulting $\phi$ is real. Now we know that our $\psi$ is a complex quantity, so there is not reason to assert that the coefficients are conjugates of each other. Thus, we take the more general decomposition
+We needed the ``coefficients'' of $e^{i\mathbf{p}\cdot \mathbf{x}}$ and those of $e^{-i\mathbf{p}\cdot \mathbf{x}}$ to be $a_\mathbf{p}$ and its conjugate $a_\mathbf{p}^\dagger$ so that the resulting $\phi$ would be real. Now we know that our $\psi$ is a complex quantity, so there is no reason to assert that the coefficients are conjugates of each other. Thus, we take the more general decomposition
 \begin{align*}
-  \psi &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}\frac{1}{\sqrt{2 E_\mathbf{p}}}(b_\mathbf{p} e^{i \mathbf{p}\cdot \mathbf{x}} + c_\mathbf{p}^\dagger e^{-i\mathbf{p}\cdot \mathbf{x}})\\
-  \psi^\dagger &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{\sqrt{2E_\mathbf{p}}} (b_\mathbf{p}^\dagger e^{-i\mathbf{p}\cdot \mathbf{x}} + c_\mathbf{p} e^{i\mathbf{p}\cdot \mathbf{x}}).
+  \psi(\mathbf{x}) &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}\frac{1}{\sqrt{2 E_\mathbf{p}}}(b_\mathbf{p} e^{i \mathbf{p}\cdot \mathbf{x}} + c_\mathbf{p}^\dagger e^{-i\mathbf{p}\cdot \mathbf{x}})\\
+  \psi^\dagger(\mathbf{x}) &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{\sqrt{2E_\mathbf{p}}} (b_\mathbf{p}^\dagger e^{-i\mathbf{p}\cdot \mathbf{x}} + c_\mathbf{p} e^{i\mathbf{p}\cdot \mathbf{x}}).
 \end{align*}
 Then the conjugate momentum is
 \begin{align*}
-  \pi &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \sqrt{\frac{E_\mathbf{p}}{2}} (b_\mathbf{p}^\dagger e^{-i\mathbf{p}\cdot \mathbf{x}} - c_\mathbf{p}e^{i\mathbf{p}\cdot \mathbf{x}})\\
-  \pi^\dagger &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}(-i) \sqrt{\frac{E_\mathbf{p}}{2}} (b_\mathbf{p} e^{i\mathbf{p}\cdot \mathbf{x}} - c_\mathbf{p}^\dagger e^{i\mathbf{p}\cdot \mathbf{x}}).
+  \pi(\mathbf{x}) &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \, i \, \sqrt{\frac{E_\mathbf{p}}{2}} (b_\mathbf{p}^\dagger e^{-i\mathbf{p}\cdot \mathbf{x}} - c_\mathbf{p}e^{i\mathbf{p}\cdot \mathbf{x}})\\
+  \pi^\dagger(\mathbf{x}) &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}(-i) \sqrt{\frac{E_\mathbf{p}}{2}} (b_\mathbf{p} e^{i\mathbf{p}\cdot \mathbf{x}} - c_\mathbf{p}^\dagger e^{-i\mathbf{p}\cdot \mathbf{x}}).
 \end{align*}
 The commutator relations are
 \[
@@ -1216,7 +1221,7 @@ are conserved.
 
 But in the classical case, we had an extra conserved charge
 \[
-  Q = i \int \d^3 \mathbf{x} (\dot{\psi}^* \psi - \psi^* \dot{\psi}) = i \int \d^3 \mathbf{x} (\pi \psi - \psi^* \pi^*).
+  Q = i \int \d^3 \mathbf{x} \; (\dot{\psi}^* \psi - \psi^* \dot{\psi}) = i \int \d^3 \mathbf{x} \; (\pi \psi - \psi^* \pi^*).
 \]
 Again by tedious computations, we can replace the $\pi$ and $\psi$ with their operator analogues, expand everything in terms of $c_\mathbf{p}$ and $b_\mathbf{p}$, throw away the pieces of infinity by requiring normal ordering, and then obtain
 \[
@@ -1260,9 +1265,9 @@ To evaluate this expression, it is often convenient to note the following result
 \end{prop}
 
 \begin{proof}
-  For $\lambda$ a real constant, note that
+  For $\lambda$ a real variable, note that
   \begin{align*}
-    \frac{\d}{\d \lambda} (e^{\lambda A}B e^{-\lambda A}) &= \lim_{\varepsilon \to 0} \frac{e^{\lambda A + \varepsilon} B e^{-\varepsilon A} - e^{\lambda A}Be^{-\lambda A}}{\varepsilon}\\
+    \frac{\d}{\d \lambda} (e^{\lambda A}B e^{-\lambda A}) &= \lim_{\varepsilon \to 0} \frac{e^{(\lambda + \varepsilon) A} B e^{-(\lambda + \varepsilon) A} - e^{\lambda A}Be^{-\lambda A}}{\varepsilon}\\
     &= \lim_{\varepsilon \to 0} e^{\lambda A}\frac{e^{\varepsilon A}B e^{-\varepsilon A}- B}{\varepsilon} e^{-\lambda A}\\
     &= \lim_{\varepsilon \to 0} e^{\lambda A}\frac{(1 + \varepsilon A)B(1 - \varepsilon A) - B + o(\varepsilon)}{\varepsilon} e^{-\lambda A}\\
     &= \lim_{\varepsilon \to 0} e^{\lambda A} \frac{(\varepsilon (AB - BA) + o(\varepsilon))}{\varepsilon}e^{-\lambda A}\\
@@ -1278,7 +1283,7 @@ To evaluate this expression, it is often convenient to note the following result
   \]
   Putting $\lambda = 1$ then gives the desired result.
 \end{proof}
-In the Heisenberg picture, one can readily directly verify that the commutators relations for our operators $\phi(\mathbf{x}, t)$ and $\pi(\mathbf{x}, t)$ now become the \emph{equal time} commutation relations
+In the Heisenberg picture, one can readily directly verify that the commutation relations for our operators $\phi(\mathbf{x}, t)$ and $\pi(\mathbf{x}, t)$ now become \emph{equal time} commutation relations
 \[
   [\phi(\mathbf{x}, t), \phi(\mathbf{y}, t)] = [\pi(\mathbf{x}, t), \pi(\mathbf{y}, t)] = 0,\quad [\phi(\mathbf{x}, t), \pi(\mathbf{y}, t)] = i \delta^3(\mathbf{x} - \mathbf{y}).
 \]
@@ -1288,28 +1293,30 @@ For an arbitrary operator $O_H$, we can compute
   &= iH e^{iHt}O_Se^{-iHt} + e^{iHt}O_S (-iH e^{-iHt})\\
   &= i[H, O_H].
 \end{align*}
-This gives the time evolution for the operators.
+where we used the fact that the Hamiltonian commutes with any function of itself. This gives the time evolution for the operators.
 
 Recall that in quantum mechanics, when we transformed into the Heisenberg picture, a miracle occurred, and the equations of motion of the operators became the usual classical equations of motion. This will happen again. For $O_S = \phi(\mathbf{x})$, we have
 \begin{align*}
   \dot{\phi}(\mathbf{x}, t) &= i[H, \phi(\mathbf{x}, t)] \\
-  &= i\int \d \mathbf{y}^3\;\frac{1}{2}[\pi^2(\mathbf{y}, t), \phi(\mathbf{x}, t)]\\
-  &= i\int \d \mathbf{y}^3\; \pi(\mathbf{x}, t) (-i \delta^3(\mathbf{x} - \mathbf{y}))\\
+  &= i\int \d^3 \mathbf{y}\;\frac{1}{2} \, [\pi^2(\mathbf{y}, t) + (\nabla_y \phi(\mathbf{y}, t))^2 + m^2 \phi^2(\mathbf{y}, t), \phi(\mathbf{x}, t)]\\
+  &= i\int \d^3 \mathbf{y}\;\frac{1}{2} \, [\pi^2(\mathbf{y}, t), \phi(\mathbf{x}, t)]\\
+  &= i\int \d^3 \mathbf{y}\;\frac{1}{2} \, \bigl( \pi(\mathbf{y}, t) [\pi(\mathbf{y}, t), \phi(\mathbf{x}, t)] + [\pi(\mathbf{y}, t), \phi(\mathbf{x}, t)] \pi(\mathbf{y}, t)\bigr)\\
+  &= i\int \d^3 \mathbf{y}\; \pi(\mathbf{y}, t) (-i \delta^3(\mathbf{x} - \mathbf{y}))\\
   &= \pi(\mathbf{x}, t).
 \end{align*}
 Similarly, we have
 \begin{align*}
   \dot{\pi}(\mathbf{x}, t) &= i[H, \pi(\mathbf{x}, t)]\\
-  &= \frac{i}{2}\int \d^3 \mathbf{y}\; [(\nabla_y \phi(\mathbf{y}, t))^2, \pi(\mathbf{x}, t)] + m^2 [\phi^2(\mathbf{y}, t), \pi(\mathbf{x}, t)]\\
+  &= \frac{i}{2}\int \d^3 \mathbf{y} \left( [(\nabla_y \phi(\mathbf{y}, t))^2, \pi(\mathbf{x}, t)] + m^2 [\phi^2(\mathbf{y}, t), \pi(\mathbf{x}, t)]\right)\\
   \intertext{Now notice that $\nabla_y$ does not interact with $\pi(\mathbf{x}, t)$. So this becomes}
-  &= \int \d^3 \mathbf{y}\; -(\nabla_y \phi(\mathbf{y}, t) \cdot \nabla_y \delta^3(\mathbf{x} - \mathbf{y})) - m^2 \phi(\mathbf{x}, t) (\delta^2(\mathbf{x} - \mathbf{y}))\\
+  &= \int \d^3 \mathbf{y} \left( -(\nabla_y \phi(\mathbf{y}, t) \cdot \nabla_y \delta^3(\mathbf{x} - \mathbf{y})) - m^2 \phi(\mathbf{y}, t) \delta^3(\mathbf{x} - \mathbf{y})\right)\\
   \intertext{Integrating the first term by parts, we obtain}
-  &= \int \d^3 \mathbf{y}\; (\nabla^2_y \phi(\mathbf{y}, t)) \delta(\mathbf{x} - \mathbf{y}) - m^2 \phi(\mathbf{x}, t) (\delta^2(\mathbf{x} - \mathbf{y}))\\
+  &= \int \d^3 \mathbf{y} \left( (\nabla^2_y \phi(\mathbf{y}, t)) \delta^3(\mathbf{x} - \mathbf{y}) - m^2 \phi(\mathbf{y}, t) \delta^3(\mathbf{x} - \mathbf{y}) \right)\\
   &= \nabla^2 \phi(\mathbf{x}, t) - m^2 \phi(\mathbf{x}, t).
 \end{align*}
 Finally, noting that $\dot{\pi} = \ddot{\phi}$ and rearranging, we obtain
 \[
-  \partial_\mu \partial^\mu \phi(\mathbf{x}, t) - m^2 \phi(\mathbf{x}, t) = 0.
+  \partial_\mu \partial^\mu \phi(\mathbf{x}, t) + m^2 \phi(\mathbf{x}, t) = 0.
 \]
 This is just the usual Klein--Gordon equation!
 
@@ -1326,7 +1333,7 @@ What happens to the creation and annihilation operators? We use our previous mag
 \end{align*}
 These extra factors of $e^{\pm iE_\mathbf{p} t}$ might seem really annoying to carry around, but they are not! They merge perfectly into the rest of our formulas relativistically. Indeed, we have
 \begin{align*}
-  \phi(\mathbf{x}, t) &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}\frac{1}{\sqrt{2 E_\mathbf{p}}} \left(a_\mathbf{p}e^{-iE_\mathbf{p} t} e^{i\mathbf{p}\cdot \mathbf{x}} + a_\mathbf{p}^\dagger e^{iE_\mathbf{p} t} e^{-i\mathbf{p}\cdot \mathbf{x}}\right)\\
+  \phi(x) \equiv \phi(\mathbf{x}, t) &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}\frac{1}{\sqrt{2 E_\mathbf{p}}} \left(a_\mathbf{p}e^{-iE_\mathbf{p} t} e^{i\mathbf{p}\cdot \mathbf{x}} + a_\mathbf{p}^\dagger e^{iE_\mathbf{p} t} e^{-i\mathbf{p}\cdot \mathbf{x}}\right)\\
   &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}\frac{1}{\sqrt{2 E_\mathbf{p}}} \left(a_\mathbf{p} e^{-ip \cdot x} + a_\mathbf{p}^\dagger e^{i p \cdot x}\right),
 \end{align*}
 where now $p \cdot x$ is the inner product of the $4$-vectors $p$ and $x$! If we use our relativistically normalized
@@ -1335,14 +1342,14 @@ where now $p \cdot x$ is the inner product of the $4$-vectors $p$ and $x$! If we
 \]
 instead, then the equation becomes
 \begin{align*}
-  \phi(\mathbf{x}, t) &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{2E_\mathbf{p}}\left(a(p) e^{-ip \cdot x} + a(p)^\dagger e^{i p \cdot x}\right),
+  \phi(x) &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{2E_\mathbf{p}}\left(a(p) e^{-ip \cdot x} + a(p)^\dagger e^{i p \cdot x}\right),
 \end{align*}
 which is made up of Lorentz invariant quantities only!
 
 Unfortunately, one should note that we are not yet completely Lorentz-invariant, as our commutation relations are \emph{equal time} commutation relations. However, this is the best we can do, at least in this course.
 
 \subsubsection*{Causality}
-Since we are doing relativistic things, it is important to ask ourselves if our theory is causal. If two points $x, y$ in spacetime are separated space-like, then a measurement of the field at $x$ should not affect the measurement of the field at $y$. So measuring $\phi(x)$ after $\phi(y)$ should give the same thing as measuring $\phi(y)$ after $\phi(x)$. So we must have $[\phi(x), \phi(y)] = 0$.
+Since we are doing relativistic things, it is important to ask ourselves if our theory is causal. If two points $x, y$ in spacetime are space-like separated, then a measurement of the field at $x$ should not affect the measurement of the field at $y$. So measuring $\phi(x)$ after $\phi(y)$ should give the same thing as measuring $\phi(y)$ after $\phi(x)$. So we must have $[\phi(x), \phi(y)] = 0$.
 
 \begin{defi}[Causal theory]\index{causal theory}
   A theory is \emph{causal} if for any space-like separated points $x, y$, and any two fields $\phi, \psi$, we have
@@ -1354,7 +1361,7 @@ Does our theory satisfy causality? For convenience, we will write
 \[
   \Delta(x - y) = [\phi(x), \phi(y)].
 \]
-We now use the familiar trick that our $\phi$ is Lorentz-invariant, so we can pick a convenient frame to do the computations. Suppose $x$ and $y$ are separated space-like. Then there is some frame where they are of the form
+We now use the familiar trick that our $\phi$ is Lorentz-invariant, so we can pick a convenient frame to do the computations. Suppose $x$ and $y$ are space-like separated. Then there is some frame where they are of the form
 \[
   x = (\mathbf{x}, t),\quad y = (\mathbf{y}, t)
 \]
@@ -1369,7 +1376,7 @@ What happens for time-like separation? We can derive the more general formula
   \Delta(x - y) &= [\phi(x), \phi(y)]\\
   &= \int \frac{\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^6}\frac{1}{\sqrt{4E_\mathbf{p} E_\mathbf{q}}} \left([a_\mathbf{p}, a_\mathbf{q}]e^{i(- p\cdot x - q\cdot y)} + [a_\mathbf{p}, a_\mathbf{q}^\dagger] e^{i(-p \cdot x + q\cdot y)}\right.\\
   &\hphantom{= \int \frac{\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^6}\frac{1}{\sqrt{4E_\mathbf{p} E_\mathbf{q}}}} \left.+[a_\mathbf{p}^\dagger, a_\mathbf{q}]e^{i(p\cdot x - q\cdot y)} + [a_\mathbf{p}^\dagger, a_\mathbf{q}^\dagger] e^{i(p\cdot x + q \cdot y)}\right)\\
-  &= \int \frac{\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^6}\frac{1}{\sqrt{4E_\mathbf{p} E_\mathbf{q}}} (2\pi)^3 \delta(\mathbf{p} - \mathbf{q}) \left(e^{i(-p \cdot x + q\cdot y)} - e^{i(p\cdot x - q \cdot y)}\right)\\
+  &= \int \frac{\d^3 \mathbf{p}\;\d^3 \mathbf{q}}{(2\pi)^6}\frac{1}{\sqrt{4E_\mathbf{p} E_\mathbf{q}}} (2\pi)^3 \delta^3(\mathbf{p} - \mathbf{q}) \left(e^{i(-p \cdot x + q\cdot y)} - e^{i(p\cdot x - q \cdot y)}\right)\\
   &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3}\frac{1}{2E_\mathbf{p}} (e^{ip\cdot(y - x)} - e^{-ip\cdot(y - x)}).
 \end{align*}
 This \emph{doesn't} vanish for time-like separation, which we may wlog be of the form $x = (\mathbf{x}, 0), y = (\mathbf{x}, t)$, since we have
@@ -1408,9 +1415,9 @@ It is not difficult to compute the value of the propagator. We have
 \]
 with all other terms in $\phi(x) \phi(y)$ vanishing because they annihilate the vacuum. We now use the fact that
 \[
-  \brak{0}a_\mathbf{p}, a_\mathbf{p}^\dagger\bket{0} = \brak{0}[a_\mathbf{p}, a_\mathbf{p}^\dagger]\bket{0} = i (2\pi)^3 \delta^3 (\mathbf{p} - \mathbf{p}'),
+  \brak{0}a_\mathbf{p} a_\mathbf{p'}^\dagger\bket{0} = \brak{0}[a_\mathbf{p}, a_\mathbf{p'}^\dagger]\bket{0} = i (2\pi)^3 \delta^3 (\mathbf{p} - \mathbf{p}'),
 \]
-since $a_\mathbf{p}^\dagger a_\mathbf{p} \bket{0} = 0$. So we have
+since $a_\mathbf{p'}^\dagger a_\mathbf{p} \bket{0} = 0$. So we have
 \begin{prop}
   \[
     D(x - y) = \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{2 E_\mathbf{p}} e^{-i p \cdot (x - y)}.
@@ -1429,6 +1436,7 @@ The propagator relates to the $\Delta(x - y)$ we previously defined by the follo
   \[
     \Delta(x - y) = [\phi(x), \phi(y)] = \brak{0}[\phi(x), \phi(y)]\bket{0} = D(x - y) - D(y - x),
   \]
+  where the second equality follows as $[\phi(x), \phi(y)]$ is just an ordinary function.
 \end{proof}
 
 For a space-like separation $(x - y)^2 < 0$, one can show that it decays as
@@ -1455,7 +1463,7 @@ As we will later see, it turns out that what actually is useful is not the above
     \end{cases}
   \]
 \end{defi}
-Note that it seems like this is not a Lorentz-invariant quantity, because we are directly comparing $x^0$ and $y^0$. However, this is actually not a problem, since when $x$ and $y$ are separated space-like, then $\phi(x)$ and $\phi(y)$ commute, and the two quantities agree.
+Note that it seems like this is not a Lorentz-invariant quantity, because we are directly comparing $x^0$ and $y^0$. However, this is actually not a problem, since when $x$ and $y$ are space-like separated, then $\phi(x)$ and $\phi(y)$ commute, and the two quantities agree.
 
 \begin{prop}
   We have
@@ -1481,13 +1489,13 @@ Note that it seems like this is not a Lorentz-invariant quantity, because we are
 \begin{proof}
   To compare with our previous computations of $D(x - y)$, we evaluate the $p^0$ integral for each $\mathbf{p}$. Writing
   \[
-    \frac{1}{p^2 - m^2} = \frac{1}{p_0^2 - E_\mathbf{p}^2} = \frac{1}{(p^0 - E_\mathbf{p})(p^0 + E_\mathbf{p})},
+    \frac{1}{p^2 - m^2} = \frac{1}{(p^0)^2 - E_\mathbf{p}^2} = \frac{1}{(p^0 - E_\mathbf{p})(p^0 + E_\mathbf{p})},
   \]
   we see that the residue of the pole at $p^0 = \pm E_\mathbf{p}$ is $\pm \frac{1}{2E_\mathbf{p}}$.
 
-  When $x^0 > y^0$, we close the contour in the lower plane $p^0 \to -i\infty$, so $e^{-p^0(x^0 - t^0)} \to e^{-\infty} = 0$. Then $\int p^0$ picks up the residue at $p^0 = E_\mathbf{p}$. So the Feynman propagator is
+  When $x^0 > y^0$, we close the contour in the lower plane $p^0 \to -i\infty$, so $e^{-p^0(x^0 - t^0)} \to e^{-\infty} = 0$. Then $\int \d p^0$ picks up the residue at $p^0 = E_\mathbf{p}$. So the Feynman propagator is
   \begin{align*}
-    \Delta_F (x - y) &= \int \frac{\d ^3 \mathbf{p}}{(2\pi)^4} \frac{(-2\pi i)}{2E_\mathbf{p}} i e^{-iE_\mathbf{p}(x^0 - y^0) + i \mathbf{p} (\mathbf{x} - \mathbf{y})}\\
+    \Delta_F (x - y) &= \int \frac{\d ^3 \mathbf{p}}{(2\pi)^4} \frac{(-2\pi i)}{2E_\mathbf{p}} i e^{-iE_\mathbf{p}(x^0 - y^0) + i \mathbf{p} \cdot (\mathbf{x} - \mathbf{y})}\\
     &= \int \frac{\d^3 \mathbf{p}}{(2\pi^3)} \frac{1}{2 E_\mathbf{p}} e^{-ip \cdot (x - y)}\\
     &= D(x - y)
   \end{align*}
@@ -1497,7 +1505,7 @@ Note that it seems like this is not a Lorentz-invariant quantity, because we are
     &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{2E_\mathbf{p}} e^{-i E_\mathbf{p}(y^0 - x^0) - i \mathbf{p}\cdot (\mathbf{y} - \mathbf{x})}\\
     \intertext{We again use the trick of flipping the sign of $\mathbf{p}$ to obtain}
     &= \int \frac{\d^3 \mathbf{p}}{(2\pi)^3} \frac{1}{2E_\mathbf{p}} e^{-ip\cdot(y - x)}\\
-    &= D(y - x).
+    &= D(y - x). \qedhere
   \end{align*}
 \end{proof}
 Usually, instead of specifying the contour, we write
@@ -1553,7 +1561,7 @@ This can be given in terms of operators by
 \end{defi}
 This is useful if we have some initial field configuration, and we want to see how it evolves in the presence of some source. This solves the ``inhomogeneous Klein--Gordon equation'', i.e.\ an equation of the form
 \[
-  \partial_\mu \partial^\mu + m^2 \phi = J(x),
+  \partial_\mu \partial^\mu \phi(x) + m^2 \phi(x) = J(x),
 \]
 where $J(x)$ is some background function.
 
@@ -1599,7 +1607,7 @@ So $\lambda_n$ isn't always dimensionless. What we can do is to compare it with 
 
 We can separate this into three cases:
 \begin{enumerate}
-  \item $n = 3$: here $E^{n - 4} = E^{-1}$ decreases with $E$. So $\lambda_n E^{n - 4}$ would be small at high energies, and large at low energies.
+  \item $n = 3$: here $E^{n - 4} = E^{-1}$ decreases with $E$. So $\lambda_3 E^{-1}$ would be small at high energies, and large at low energies.
 
 % This in fact happens in reality, as we have a term like this in the standard model for couplings of the Higgs boson.
 
@@ -1628,7 +1636,7 @@ We will quickly describe some interaction Lagrangians that we will study in more
 
 We also have a Lagrangian that involves two fields --- a real scalar field and a complex scalar field.
 \begin{eg}[Scalar Yukawa theory]\index{scalar Yukawa theory}
-  In the early days, we found things called \emph{pions} that seemed to mediate nuclear reactions. At that time, people did not know that things are made up of quarks. So they modelled these pions in terms of scalar field, and we have
+  In the early days, we found things called \emph{pions} that seemed to mediate nuclear reactions. At that time, people did not know that things are made up of quarks. So they modelled these pions in terms of a scalar field, and we have
   \[
     \mathcal{L} = \partial_\mu \psi^* \partial^\mu \psi + \frac{1}{2} \partial_\mu \phi \partial^\mu \phi - M^2 \psi^* \psi - \frac{1}{2} m^2 \phi^2 - g \psi^* \psi \phi.
   \]
@@ -1636,7 +1644,7 @@ We also have a Lagrangian that involves two fields --- a real scalar field and a
 
   A wary --- the potential
   \[
-    V = M^2 \psi^* \psi + \frac{1}{2} m \phi^2 + g \psi^*\psi \phi
+    V = M^2 \psi^* \psi + \frac{1}{2} m^2 \phi^2 + g \psi^*\psi \phi
   \]
   has a stable local minimum when the fields are zero, but it is unbounded below for large $-g \phi$. So we can't push the theory too far.
 \end{eg}
@@ -1645,7 +1653,7 @@ We also have a Lagrangian that involves two fields --- a real scalar field and a
 \subsection{Interaction picture}
 How do we actually study interacting fields? We can imagine that the Hamiltonian is split into two parts, one of which is the ``free field'' part $H_0$, and the other part is the ``interaction'' part $H_{\mathrm{int}}$. For example, in the $\phi^4$ theory, we can split it up as
 \[
-  H = \int\d x^3\;\left(\vphantom{\frac{\lambda}{4}}\right.\underbrace{\frac{1}{2} (\pi^2 + (\nabla \phi)^2 + m^2 \phi^2)}_{H_0} + \underbrace{\frac{\lambda}{4!} \phi^4}_{H_{\mathrm{int}}}\left.\vphantom{\frac{\lambda}{4!}}\right).
+  H = \int\d \mathbf{x}^3\;\left(\vphantom{\frac{\lambda}{4}}\right.\underbrace{\frac{1}{2} (\pi^2 + (\nabla \phi)^2 + m^2 \phi^2)}_{H_0} + \underbrace{\frac{\lambda}{4!} \phi^4}_{H_{\mathrm{int}}}\left.\vphantom{\frac{\lambda}{4!}}\right).
 \]
 The idea is that the \term{interaction picture} mixes the Schr\"odinger picture and the Heisenberg picture, where the simple time evolutions remain in the operators, whereas the complicated interactions live in the states. This is a very useful trick if we want to deal with small interactions.
 
@@ -1700,7 +1708,7 @@ In this picture, the time evolution operator is just the identity map
 In the interaction picture, we do a mixture of both. We only shift the ``free'' part of the Hamiltonian to the operators. We define
 \begin{align*}
   O_I(t) &= e^{iH_0 t}O_S(t) e^{-iH_0 t}\\
-  \bket{\psi(t)} &= e^{iH_0 t}\bket{\psi(t)}_S.
+  \bket{\psi(t)}_I &= e^{iH_0 t}\bket{\psi(t)}_S.
 \end{align*}
 In this picture, both the operators and the states change in time!
 
@@ -1709,23 +1717,23 @@ Why is this a good idea? When we studied the Heisenberg picture of the free theo
 \begin{prop}
   In the interaction picture, the equations of motion are
   \begin{align*}
-    \frac{\d}{\d t}O_I(t) &= i [H_0, O_I]\\
+    \frac{\d}{\d t}O_I &= i [H_0, O_I]\\
     \frac{\d}{\d t}\bket{\psi(t)}_I &= H_I\bket{\psi(t)}_I,
   \end{align*}
   where $H_I$ is defined by
   \[
-    H_I = (H_{\mathrm{int}})_I = e^{iH_0 t} O_S e^{-iH_0 t}.
+    H_I = (H_{\mathrm{int}})_I = e^{iH_0 t} (H_{\mathrm{int}})_S e^{-iH_0 t}.
   \]
 \end{prop}
 
 \begin{proof}
   The first part we've essentially done before, but we will write it out again for completeness.
   \begin{align*}
-    \frac{\d}{\d t} (e^{iH_0 t}O_S e^{-iH_0 t}) &= \lim_{\varepsilon \to 0} \frac{e^{iH_0t + iH_0 \varepsilon} O_S e^{iH_0 \varepsilon} - e^{-iH_0 t}O_Se^{iH_0 t}}{\varepsilon}\\
-    &= \lim_{\varepsilon \to 0} e^{-iH_0 t}\frac{e^{-iH_0 \varepsilon}O_S e^{iH_0 \varepsilon}- O_S}{\varepsilon} e^{iH_0 t}\\
-    &= \lim_{\varepsilon \to 0} e^{-iH_0 t}\frac{(1 + -iH_0 \varepsilon)O_S(1 + iH_0 \varepsilon) - O_S + o(\varepsilon)}{\varepsilon} e^{iH_0 t}\\
-    &= \lim_{\varepsilon \to 0} e^{-iH_0 t} \frac{i\varepsilon (H_0 O_S - O_SH_0 ) + o(\varepsilon)}{\varepsilon}e^{iH_0 t}\\
-    &= e^{-iH_0 t}i [H_0 , O_S] e^{iH_0 t}\\
+    \frac{\d}{\d t} (e^{iH_0 t}O_S e^{-iH_0 t}) &= \lim_{\varepsilon \to 0} \frac{e^{iH_0(t +  \varepsilon)} O_S e^{-iH_0(t +\varepsilon)} - e^{iH_0 t}O_Se^{-iH_0 t}}{\varepsilon}\\
+    &= \lim_{\varepsilon \to 0} e^{iH_0 t}\frac{e^{iH_0 \varepsilon}O_S e^{-iH_0 \varepsilon}- O_S}{\varepsilon} e^{-iH_0 t}\\
+    &= \lim_{\varepsilon \to 0} e^{iH_0 t}\frac{(1 + iH_0 \varepsilon)O_S(1 - iH_0 \varepsilon) - O_S + o(\varepsilon)}{\varepsilon} e^{-iH_0 t}\\
+    &= \lim_{\varepsilon \to 0} e^{iH_0 t} \frac{i\varepsilon (H_0 O_S - O_S H_0) + o(\varepsilon)}{\varepsilon}e^{-iH_0 t}\\
+    &= e^{iH_0 t}i [H_0 , O_S] e^{-iH_0 t}\\
     &= i [H_0, O_I].
   \end{align*}
   For the second part, we start with Schr\"odinger's equation
@@ -1742,7 +1750,7 @@ Why is this a good idea? When we studied the Heisenberg picture of the free theo
   \]
   Rearranging gives us
   \[
-    i \frac{\d \bket{\psi(t)}_I}{\d t} = e^{iH_0 t} H_{\mathrm{int}} e^{-iH_0 t} \bket{\psi(t)}_I.
+    i \frac{\d \bket{\psi(t)}_I}{\d t} = e^{iH_0 t} (H_{\mathrm{int}})_S e^{-iH_0 t} \bket{\psi(t)}_I. \qedhere
   \]
 \end{proof}
 To obtain information about the state at time $t$, we look at what happens when we apply
@@ -1785,9 +1793,9 @@ Yet, this is a good guess, and to get the real answer, we just need to make a sl
   \[
     U(t, t_0) = T\exp\left(-i \int_{t_0}^t H_I(t') dt'\right),
   \]
-  where $T$ stands for \term{time ordering}: operators evaluated at earlier times appear on the RHS when we write out the power series. More explicitly,
+  where $T$ stands for \term{time ordering}: operators evaluated at earlier times appear to the right of operators evaluated at leter times when we write out the power series. More explicitly,
   \[
-    T\{O_1(t_1) O(t_2)\} =
+    T\{O_1(t_1) O_2(t_2)\} =
     \begin{cases}
       O_1(t_1) O_2(t_2) & t_1 > t_2\\
       O_2(t_2) O_1(t_1) & t_2 > t_1
@@ -1804,7 +1812,7 @@ Yet, this is a good guess, and to get the real answer, we just need to make a sl
   \[
     \int_{t_0}^t \d t' \int_{t'}^t \;\d t''\; H_I(t'') H_I(t') = \int_{t_0}^t \d t'' \int_{t_0}^{t''}\d t'\; H_I(t'') H_I(t'),
   \]
-  since we are both integrating over all $0 \leq t' \leq t'' \leq t$. Swapping $t'$ and $t''$ shows that the two second-order terms are indeed the same, so we have
+  since we are integrating over all $0 \leq t' \leq t'' \leq t$ on both sides. Swapping $t'$ and $t''$ shows that the two second-order terms are indeed the same, so we have
   \[
     U(t, t_0) = 1 - i \int_{t_0}^t\; H_I (t') + (-i)^2 \int_{t_0}^t \d t' \int_{t_0}^{t'} \d t'' \; H_I(t'') H_I(t') + \cdots.
   \]
@@ -1860,45 +1868,45 @@ What we now want to find is the quantity
 \end{defi}
 Here $S$ stands for ``scattering''. So we often just write our desired quantity as $\brak{f}S\bket{i}$ instead. When we evaluate this thing, we will end up with some numerical expression, which will very obviously not be a probability (it contains a delta function). We will come back to interpreting this quantity later. For the moment, we will just try to come up with ways to compute it in a sensible manner.
 
-Now let's look at that expression term by term in the Taylor expansion of $U$. The first term is the identity $1$, and we have a contribution of
+Now let's look at that expression term by term in the Taylor expansion of $U$. The first term is the identity $\mathbf{1}$, and we have a contribution of
 \[
-  \brak{f}1\bket{i} = \braket{f}{i} = 0
+  \brak{f}\mathbf{1}\bket{i} = \braket{f}{i} = 0
 \]
-since distinct eigenstates are orthogonal. In the next term, we are integrating over $\psi^\dagger \psi \phi$. If we expand this out, we will get loads of terms, each of which is a product of some $b, c, a$ (or their conjugates). But the only term that contributes would be the term $c_{\mathbf{q}_2}b_{\mathbf{q}_1}a_{\mathbf{p}}^\dagger$, so that we exactly destroy the $a_\mathbf{p}^\dagger$ particle and create the $b_{\mathbf{q}_1}$ and $c_{\mathbf{q}_2}$ particles. The other terms will end up transforming $\bket{i}$ to something that is not $\bket{f}$ (or perhaps it would kill $\bket{i}$ completely), and then the inner product will $\bket{f}$ will give $0$.
+since distinct eigenstates are orthogonal. In the next term, we are integrating over $\psi^\dagger \psi \phi$. If we expand this out, we will get loads of terms, each of which is a product of some $b, c, a$ (or their conjugates). But the only term that contributes would be the term $c_{\mathbf{q}_2}b_{\mathbf{q}_1}a_{\mathbf{p}}^\dagger$, so that we exactly destroy the $a_\mathbf{p}^\dagger$ particle and create the $b_{\mathbf{q}_1}$ and $c_{\mathbf{q}_2}$ particles. The other terms will end up transforming $\bket{i}$ to something that is not $\bket{f}$ (or perhaps it would kill $\bket{i}$ completely), and then the inner product with $\bket{f}$ will give $0$.
 
 Before we go on to discuss what the higher order terms do, we first actually compute the contribution of the first order term.
 
 We want to compute
 \begin{align*}
-  \brak{f}S\bket{i} &= \brak{f}I - i\int \d t\; H_I(t) + \cdots\bket{i}\\
-  \intertext{We know the $I$ contributes nothing, and we drop the higher order terms to get}
+  \brak{f}S\bket{i} &= \brak{f}\mathbf{1} - i\int \d t\; H_I(t) + \cdots\bket{i}\\
+  \intertext{We know the $\mathbf{1}$ contributes nothing, and we drop the higher order terms to get}
   &\approx -i \brak{f} \int \d t\; H_I(t) \bket{i}\\
   &= -ig \brak{f}\int \d^4 x\; \psi^\dagger(x) \psi(x) \phi(x) \bket{i}\\
-  &= -ig \int \d^4 x\; \brak{f}\psi^\dagger(x) \psi(x) \phi(x) \bket{i}.
+  &= -ig \int \d^4 x \brak{f}\psi^\dagger(x) \psi(x) \phi(x) \bket{i}.
 \end{align*}
 We now note that the $\bket{i}$ interacts with the $\phi$ terms only, and the $\brak{f}$ interacts with the $\psi$ terms only, so we can evaluate $\phi(x)\bket{i}$ and $\psi^\dagger (x)\psi(x) \bket{f}$ separately. Moreover, any leftover $a^\dagger, b^\dagger, c^\dagger$ terms in the expressions will end up killing the other object, as the $a^\dagger$'s commute with the $b^\dagger, c^\dagger$, and $\brak{0}a^\dagger = (a \bket{0})^\dagger = 0$.
 
-We have
+We can expand $\phi$ in terms of the creation and annihilation operators $a$ and $a^\dagger$ to get
 \[
   \phi(x) \bket{i} = \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \frac{\sqrt{2 E_\mathbf{p}}}{\sqrt{2 E_\mathbf{q}}} (a_\mathbf{q} e^{-iq\cdot x} + a_\mathbf{q}^\dagger e^{iq\cdot x}) a_\mathbf{p}^\dagger \bket{0}\\
 \]
 We notice that nothing happens to the $a_\mathbf{q}^\dagger$ terms and they will end up becoming $0$ by killing $\brak{0}$. Swapping $a_\mathbf{q}$ and $a_\mathbf{p}^\dagger$ and inserting the commutator, we obtain
 \begin{align*}
   &\hphantom{=}\int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \frac{\sqrt{2 E_\mathbf{p}}}{\sqrt{2 E_\mathbf{q}}} ([a_\mathbf{q}, a_\mathbf{p}^\dagger] + a_\mathbf{p}^\dagger a_\mathbf{q}) e^{-iq\cdot x} \bket{0}\\
-  &= \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \frac{\sqrt{2 E_{\mathbf{p}}}}{\sqrt{2 E_\mathbf{q}}} (2\pi)^3 \delta(\mathbf{p} - \mathbf{q}) e^{-iq\cdot x} \bket{0}\\
+  &= \int \frac{\d^3 \mathbf{q}}{(2\pi)^3} \frac{\sqrt{2 E_{\mathbf{p}}}}{\sqrt{2 E_\mathbf{q}}} (2\pi)^3 \delta^3(\mathbf{p} - \mathbf{q}) e^{-iq\cdot x} \bket{0}\\
   &= e^{-ip\cdot x}\bket{0}.
 \end{align*}
-We can expand $\phi$ in terms of the creation and annihilation operators $a$ and $a^\dagger$. We will use this to describe the creation and destruction of mesons.
+We will use this to describe the creation and destruction of mesons.
 
 We can similarly look at
 \begin{align*}
   &\hphantom{=}\psi^\dagger (x) \psi(x) \bket{f} \\
-  &= \int \frac{\d^3 \mathbf{k}_1\;\d^3 \mathbf{k}_2}{(2\pi)^6} \frac{1}{\sqrt{4E_{\mathbf{k}_1} E_{\mathbf{k}_2}}}(b^\dagger_{\mathbf{k}_1} e^{ik_1\cdot x} + c_{\mathbf{k}_1} e^{-ik_1\cdot x})(b_{\mathbf{k}_2} e^{-ik_2 \cdot x} + c_{\mathbf{k}_2}^\dagger e^{-i k_2 \cdot x})\bket{f}
+  &= \int \frac{\d^3 \mathbf{k}_1\;\d^3 \mathbf{k}_2}{(2\pi)^6} \frac{1}{\sqrt{4E_{\mathbf{k}_1} E_{\mathbf{k}_2}}}(b^\dagger_{\mathbf{k}_1} e^{ik_1\cdot x} + c_{\mathbf{k}_1} e^{-ik_1\cdot x})(b_{\mathbf{k}_2} e^{-ik_2 \cdot x} + c_{\mathbf{k}_2}^\dagger e^{i k_2 \cdot x})\bket{f}
 \end{align*}
 As before, the only interesting term for us is when we have both $c_{\mathbf{k}_1}$ and $b_{\mathbf{k}_2}$ present to ``kill'' $b_{\mathbf{q}_1}^\dagger c_{\mathbf{q}_2}^\dagger$ in $\bket{f}$. So we look at
 \begin{align*}
   &\hphantom{=} \int \frac{\d^3 \mathbf{k}_1 \; \d^3 \mathbf{k}_2}{(2\pi)^6} \frac{\sqrt{4E_{\mathbf{q}_1}E_{\mathbf{q}_2}}}{\sqrt{4 E_{\mathbf{k}_1} E_{\mathbf{k}_2}}} c_{\mathbf{k}_1} b_{\mathbf{k}_2}b_{\mathbf{q}_1}^\dagger c_{\mathbf{q}_2}^\dagger e^{-i(k_1 + k_2) \cdot x}\bket{0}\\
-  &= \int \frac{\d^3 \mathbf{k}_1 \;\d \mathbf{k}_2}{(2\pi)^6} (2\pi)^6 \delta(\mathbf{q}_1 - \mathbf{k}_1)\delta(\mathbf{q}_2 - \mathbf{k}_2) e^{-i(k_1 + k_2)\cdot x}\bket{0}\\
+  &= \int \frac{\d^3 \mathbf{k}_1 \;\d^3 \mathbf{k}_2}{(2\pi)^6} (2\pi)^6 \delta^3(\mathbf{q}_1 - \mathbf{k}_2)\delta^3(\mathbf{q}_2 - \mathbf{k}_1) e^{-i(k_1 + k_2)\cdot x}\bket{0}\\
   &= e^{-i(q_1 + q_2)\cdot x}\bket{0}.
 \end{align*}
 So we have
@@ -1907,7 +1915,7 @@ So we have
   &= -ig \int \d^4 x\; e^{i(q_1 + q_2 - p) \cdot x}\\
   &= -ig (2\pi)^4 \delta^4(q_1 + q_2 - p).
 \end{align*}
-If we look carefully at what we have done, what allowed us to go from initial $\phi$ state $\bket{i} = \sqrt{2 E_\mathbf{p}} a_\mathbf{p}^\dagger\bket{0}$ to the final $\psi\bar\psi$ state $\bket{f} = \sqrt{4 E_{\mathbf{q}_1} E_{\mathbf{q}_2}}$ is the presence of the term $c_{\mathbf{q}_1}^\dagger b_{\mathbf{q}_2}^\dagger a_\mathbf{p}$ in the $S$ matrix (what we appeared to have used in the calculation was $c_{\mathbf{q}_1} b_{\mathbf{q}_2}$ instead of their conjugates, but that is because we were working with the conjugate $\psi^\dagger \psi \bket{f}$ rather than $\brak{f} \psi^\dagger \psi$).
+If we look carefully at what we have done, what allowed us to go from the initial $\phi$ state $\bket{i} = \sqrt{2 E_\mathbf{p}} a_\mathbf{p}^\dagger\bket{0}$ to the final $\psi\bar\psi$ state $\bket{f} = \sqrt{4 E_{\mathbf{q}_1} E_{\mathbf{q}_2}} b_{\mathbf{q}_1}^\dagger c_{\mathbf{q}_2}^{\dagger} \bket{0}$ was the presence of the term $c_{\mathbf{q}_1}^\dagger b_{\mathbf{q}_2}^\dagger a_\mathbf{p}$ in the $S$ matrix (what we appeared to have used in the calculation was $c_{\mathbf{q}_1} b_{\mathbf{q}_2}$ instead of their conjugates, but that is because we were working with the conjugate $\psi^\dagger \psi \bket{f}$ rather than $\brak{f} \psi^\dagger \psi$).
 
 If we expand the $S$-matrix to, say, second order, we will, for example, find a term that looks like $(c^\dagger b^\dagger a)(cba^\dagger)$. This corresponds to destroying a $\psi \bar{\psi}$ pair to produce a $\phi$, then destroying that to recover another $\psi \bar\psi$ pair, which is an interaction of the form
 \begin{center}
@@ -1977,15 +1985,15 @@ We now compute the contraction of our favorite scalar fields:
   \end{align*}
   So we have
   \[
-    T\phi(x) \phi(y) = \normalorder{\phi(x) \phi(y)} + D(x - y).
+    T\phi(x) \phi(y) = \normalorder{\phi(x) \phi(y)} + \, D(x - y).
   \]
   By symmetry, for $y^0 > x^0$, we have
   \[
-    T\phi(x) \phi(y) = \normalorder{\phi(x)\phi(y)} + D(y - x).
+    T\phi(x) \phi(y) = \normalorder{\phi(x)\phi(y)} + \, D(y - x).
   \]
   Recalling the definition of the Feynman propagator, we have
   \[
-    T\phi(x)\phi(y) = \normalorder{\phi(x) \phi(y)} + \Delta_F(x - y). \qedhere
+    T\phi(x)\phi(y) = \normalorder{\phi(x) \phi(y)} + \, \Delta_F(x - y). \qedhere
   \]
 \end{proof}
 
@@ -2006,14 +2014,14 @@ It turns out these computations are all we need to figure out how to turn a time
 \begin{thm}[Wick's theorem]\index{Wick's theorem}
   For any collection of fields $\phi_1 = \phi_1(x_1), \phi_2 = \phi_2(x_2), \cdots$, we have
   \[
-    T(\phi_1 \cdots \phi_n) = :\phi_1 \phi_2 \cdots \phi_n: + \text{ all possible contractions}
+    T(\phi_1 \phi_2 \cdots \phi_n) = \normalorder{\phi_1 \phi_2 \cdots \phi_n} + \text{ all possible contractions}
   \]
 \end{thm}
 
 \begin{eg}
   We have
   \[
-    T(\phi_1 \phi_2 \phi_3 \phi_4) = :\phi_1 \phi_2 \phi_3 \phi_4: + \contraction{}{\phi_1}{}{\phi_2}\phi_1 \phi_2 : \phi_3 \phi_4: + \contraction{}{\phi_1}{}{\phi_3}\phi_1 \phi_3:\phi_2 \phi_4: + \cdots + \contraction{}{\phi_1}{\phi_2}{\phi_3}\contraction[1.5ex]{\phi_1}{\phi_2}{\phi_3}{\phi_4}\phi_1\phi_2\phi_3\phi_4\cdots
+    T(\phi_1 \phi_2 \phi_3 \phi_4) = \normalorder{\phi_1 \phi_2 \phi_3 \phi_4} + \, \contraction{}{\phi_1}{}{\phi_2}\phi_1 \phi_2 \normalorder{ \phi_3 \phi_4} + \, \contraction{}{\phi_1}{}{\phi_3}\phi_1 \phi_3 \normalorder{\phi_2 \phi_4} + \cdots + \contraction{}{\phi_1}{\phi_2}{\phi_3}\contraction[1.5ex]{\phi_1}{\phi_2}{\phi_3}{\phi_4}\phi_1\phi_2\phi_3\phi_4 + \cdots
   \]
 \end{eg}
 
@@ -2026,7 +2034,7 @@ It turns out these computations are all we need to figure out how to turn a time
   \]
   Then we have
   \[
-    T(\phi_1 \cdots \phi_n) = (\phi_1^+ + \phi_1^-)(:\phi_2 \cdots \phi_n: + \text{ other contractions}).
+    T(\phi_1 \cdots \phi_n) = (\phi_1^+ + \phi_1^-)(\normalorder{\phi_2 \cdots \phi_n} + \text{ other contractions}).
   \]
   The $\phi^-$ term stays where it is, as that already gives normal ordering, and the $\phi_1^+$ term has to make its way past the $\phi_k^-$ operators. So we can write the RHS as a normal-ordered product. Each time we move past the $\phi_k^-$, we pick up a contraction $\contraction{}{\phi_1}{}{\phi_n}\phi_1\phi_k$. % insert an example
 \end{proof}
@@ -2062,11 +2070,11 @@ It turns out these computations are all we need to figure out how to turn a time
     \bket{i} &= \sqrt{4 E_{\mathbf{p}_1} E_{\mathbf{p}_2}} b_{\mathbf{p}_1}^\dagger b_{\mathbf{p}_2}^\dagger\bket{0}\\
     \bket{f} &= \sqrt{4 E_{\mathbf{p}_1'} E_{\mathbf{p}_2'}} b_{\mathbf{p}_1'}^\dagger b_{\mathbf{p}_2'}^\dagger\bket{0}
   \end{align*}
-  We look at the order $g^2$ term in $\brak{f}(S - I)\bket{i}$. We remove that $I$ as we are not interested in the case with no scattering, and we look at order $g^2$ because there is no order $g$ term.
+  We look at the order $g^2$ term in $\brak{f}(S - \mathbf{1})\bket{i}$. We remove that $\mathbf{1}$ as we are not interested in the case with no scattering, and we look at order $g^2$ because there is no order $g$ term.
 
   The second order term is given by
   \[
-    \frac{(-ig)^2}{2}\int \d^4 x_1 \d^4 x_2 T\left[\psi^+(x_1) \psi(x_1) \phi(x_1) \psi^+(x_2) \psi(x_2) \phi(x_2)\right].
+    \frac{(-ig)^2}{2}\int \d^4 x_1 \d^4 x_2 \; T\left[\psi^\dagger(x_1) \psi(x_1) \phi(x_1) \psi^\dagger(x_2) \psi(x_2) \phi(x_2)\right].
   \]
   Now we can use Wick's theorem to write the time-ordered product as a sum of normal-ordered products. The annihilation and creation operators don't end up killing the vacuum only if we annihilate two $b_\mathbf{p}$ and then construct two new $b_\mathbf{p}$. This only happens in the term
   \[
@@ -2078,7 +2086,7 @@ It turns out these computations are all we need to figure out how to turn a time
   \]
   The only relevant term in the normal-ordered product is
   \[
-    \iiiint \frac{\d^3 \mathbf{k}_1\;\d^3 \mathbf{k}_2 \;\d^3 \mathbf{k}_3 \;\d^3 \mathbf{k}_4}{(2\pi)^{12}\sqrt{16 E_{\mathbf{k}_1} E_{\mathbf{k}_2} E_{\mathbf{k}_3} E_{\mathbf{k}_3}}} b_{\mathbf{k}_1}^\dagger b_{\mathbf{k}_2}^\dagger b_{\mathbf{k}_3} b_{\mathbf{k}_4} e^{ik_1 \cdot x_1 + i k_2 \cdot x_2 - i k_3 \cdot x_1 - i k_4 \cdot x_2}.
+    \iiiint \frac{\d^3 \mathbf{k}_1\;\d^3 \mathbf{k}_2 \;\d^3 \mathbf{k}_3 \;\d^3 \mathbf{k}_4}{(2\pi)^{12}\sqrt{16 E_{\mathbf{k}_1} E_{\mathbf{k}_2} E_{\mathbf{k}_3} E_{\mathbf{k}_4}}} b_{\mathbf{k}_1}^\dagger b_{\mathbf{k}_2}^\dagger b_{\mathbf{k}_3} b_{\mathbf{k}_4} e^{ik_1 \cdot x_1 + i k_2 \cdot x_2 - i k_3 \cdot x_1 - i k_4 \cdot x_2}.
   \]
   Now letting this act on $\brak{p_1', p_2'}$ and $\bket{p_1, p_2}$ would then give
   \[
@@ -2130,9 +2138,9 @@ We begin by specifying what diagrams are ``allowed'', and then specify how we as
 
 Given an initial state and final state, the possible Feynman diagrams are specified as follows:
 \begin{defi}[Feynman diagram]\index{Feynman diagram!scalar Yukawa theory}\index{Feynman diagram}
-  In the scalar Yukawa theory, given an initial state $\bket{i}$ and final state $\bket{f}$, a \emph{Feynman diagram} is consists of:
+  In the scalar Yukawa theory, given an initial state $\bket{i}$ and final state $\bket{f}$, a \emph{Feynman diagram} consists of:
   \begin{itemize}
-    \item Draw an external line for all particles in the initial and final states. A dashed line is used for a $\phi$-particle, and solid lines are used for $\psi$/$\bar\psi$-particles.
+    \item An external line for all particles in the initial and final states. A dashed line is used for a $\phi$-particle, and solid lines are used for $\psi$/$\bar\psi$-particles.
     \begin{center}
       \begin{tikzpicture}
         \begin{feynman}
@@ -2636,11 +2644,11 @@ Similarly, we have
   So the result follows. The other direction follows similarly.
 \end{proof}
 
-Now given that we have this vacuum, we can now define the \emph{correlation function function}.
+Now given that we have this vacuum, we can define the \emph{correlation function}.
 \begin{defi}[Correlation/Green's function]\index{correlation function}\index{Green's function}
   The \emph{correlation} or \emph{Green's function} is defined as
   \[
-    G^{(n)}(x_1, \cdots, x_n) = \brak{\Omega}T \phi_H(x_1), \cdots, \phi_H(x_n)\bket{\Omega},
+    G^{(n)}(x_1, \cdots, x_n) = \brak{\Omega}T \phi_H(x_1) \cdots \phi_H(x_n)\bket{\Omega},
   \]
   where $\phi_H$ denotes the operators in the Heisenberg picture.
 \end{defi}
@@ -2831,7 +2839,7 @@ We can come up with analogous Feynman rules to figure out the contribution of al
 
 There is also another way we can think about these Green's function. Consider the theory with a source $J(x)$ added, so that
 \[
-  \mathcal{H} = H_0 + H_{\mathrm{int}} - J(x) \phi(x).
+  H = H_0 + H_{\mathrm{int}} - J(x) \phi(x).
 \]
 This $J$ is a fixed background function, called a source in analogy with electromagnetism.
 

--- a/III_M/quantum_field_theory.tex
+++ b/III_M/quantum_field_theory.tex
@@ -1814,7 +1814,7 @@ Yet, this is a good guess, and to get the real answer, we just need to make a sl
   \]
   since we are integrating over all $0 \leq t' \leq t'' \leq t$ on both sides. Swapping $t'$ and $t''$ shows that the two second-order terms are indeed the same, so we have
   \[
-    U(t, t_0) = 1 - i \int_{t_0}^t\; H_I (t') + (-i)^2 \int_{t_0}^t \d t' \int_{t_0}^{t'} \d t'' \; H_I(t'') H_I(t') + \cdots.
+    U(t, t_0) = 1 - i \int_{t_0}^t \d t' \; H_I (t') + (-i)^2 \int_{t_0}^t \d t' \int_{t_0}^{t'} \d t'' \; H_I(t'') H_I(t') + \cdots.
   \]
 \end{prop}
 


### PR DESCRIPTION
I've corrected a number of typos and made a few changes, which of course are just my suggestions for improvement, such as:
- I've added one or two lines to some computations which, at first, I found a bit obscure. Hopefully what I added will be helpful 
- Also, I may be wrong, but I think the computations in the proof of `e^A B e^{-A} = ...`  and a similar one for the Heisenberg operator equation of motion had something wrong in the exponents
- I've replaced some `I`'s with `\mathbf{1}` near the `S` of S-matrix since in one case it appears in an integral where we also have an `I` for "interaction picture" and in another near a `p_I` for the momentum, so I think it's better to have different symbols. You did use `\mathbf{1}` as notation for the identity elsewhere in the notes
- Some of the 3-d delta functions were missing the exponent
- I tried to make the notation more consistent in some places and a few other little things.

I will be looking at the section on spinors soon, so I will probably have some more.
Once again, thank you for sharing your notes.