### PR TITLE
Mistake in geometry

### DIFF
--- a/IB_L/geometry.tex
+++ b/IB_L/geometry.tex
@@ -2841,7 +2841,7 @@ This is purely a technical result.
   Thus we know
   \begin{align*}
     K \sqrt{G} &= (\mathbf{N}_u \times \mathbf{N}_v) \cdot \mathbf{N} \\
-    &= (\mathbf{N}_u \times \mathbf{N}_v) \times (\mathbf{e}\times \mathbf{f})\\
+    &= (\mathbf{N}_u \times \mathbf{N}_v) \cdot (\mathbf{e}\times \mathbf{f})\\
     &= (\mathbf{N}_u \cdot \mathbf{e})(\mathbf{N}_v \cdot \mathbf{f}) - (\mathbf{N}_u \cdot \mathbf{f}) (\mathbf{N}_v \cdot \mathbf{e}).
   \end{align*}
   Since $\mathbf{N}\cdot \mathbf{e} = 0$, we know


### PR DESCRIPTION
Corrected error in curvature formula proof: \times should be \cdot