### PR TITLE
Correct a small typo

### DIFF
--- a/IA_M/differential_equations.tex
+++ b/IA_M/differential_equations.tex
@@ -403,7 +403,7 @@ In general, we can derive the following formula:
   \end{align*}
 \end{proof}
 \subsection{Differentiation of an integral wrt parameter in the integrand}
-Consider a family of functions $f(x, c)$. Define $I(b, c) = \int_0^bf(x, c)\d x$. Then by the fundamental theorem of calculus, we have $\frac{\partial I}{\partial b} = f(x, c)$. On the other hand, we have
+Consider a family of functions $f(x, c)$. Define $I(b, c) = \int_0^bf(x, c)\d x$. Then by the fundamental theorem of calculus, we have $\frac{\partial I}{\partial b} = f(b, c)$. On the other hand, we have
 \begin{align*}
   \frac{\partial I}{\partial c} &= \lim_{\delta c\to 0}\frac{1}{\delta c}\left[\int_0^bf(x, c + \delta c)\d x - \int_0^b f(x, c)\;\d x\right]\\
   &= \lim_{\delta c\to 0}\int_0^b\frac{f(x, c + \delta c) - f(x, c)}{\delta c}\;\d x\\


### PR DESCRIPTION
I believe it should be `b` rather than `x` because:

1. `x` is not a free variable on the RHS, since we are integrating over `x`, `x` must disappear

2. `b` is consistent with the expansion of `dI/dx` you give immediately afterwards