### PR TITLE
Minor typos

### DIFF
--- a/IA_M/differential_equations.tex
+++ b/IA_M/differential_equations.tex
@@ -767,7 +767,7 @@ If the equation is exact, then the solution is simply $f = $ constant, and we ca
   \]
   Since the original equation was $\d f = 0$, we have $f = $ constant. Thus the final solution is
   \[
-    x^2 - 3xy^2 + 3y^3 = C.
+    x^2 - 3xy^2 + 2y^3 = C.
   \]
 \end{eg}
 
@@ -2092,7 +2092,7 @@ and
 In conclusion, we have
 \begin{align*}
   f(x, y) &= f(x_0, y_0) + (x - x_0)f_x + (y - y_0)f_y \\
-  &+ \frac{1}{2}[(x - x_0)^2 f_{xx} + 2(x - x_0)(y - y_0)f_{xy} + (y - y_0)^2 f_yy]
+  &+ \frac{1}{2}[(x - x_0)^2 f_{xx} + 2(x - x_0)(y - y_0)f_{xy} + (y - y_0)^2 f_{yy}]
 \end{align*}
 In general, the coordinate-free form is
 \[
@@ -2606,7 +2606,7 @@ This is a linear system, and we can determine its character from the eigensoluti
   \begin{center}
     \includegraphics[width=180pt]{images/de_population_phase.pdf}
   \end{center}
-  We see that $(1, 3)$ is a stable solution in which almost all solutions spiral towards.
+  We see that $(1, 3)$ is a stable solution which almost all solutions spiral towards.
 \end{eg}
 
 \section{Partial differential equations (PDEs)}
@@ -2700,7 +2700,7 @@ We consider equations in the following form:
 \]
 This is the \emph{second-order wave equation}, and is often known as the ``hyperbolic equation'' because the form resembles that of a hyperbola (which has the form $x^2 - b^2 y^2 = 0$). However, the differential equation has no connections to hyperbolae whatsoever.
 
-This equation models an actual wave in one dimensions. Consider a horizontal string, along the $x$ axis. We let $y(x, t)$ be the vertical displacement of the string at the point $x$ at time $t$.
+This equation models an actual wave in one dimension. Consider a horizontal string, along the $x$ axis. We let $y(x, t)$ be the vertical displacement of the string at the point $x$ at time $t$.
 \begin{center}
   \begin{tikzpicture}
     \draw (0, 0) sin (1.5, 0.667) cos (3, 0) sin (4.5, -0.667) cos (6, 0);


### PR DESCRIPTION
(PDF page numbers for reference)

pg. 22: I think you made a mistake while copying the coefficient of y^3 from the previous line
pg: 52: Brackets were missing around "yy" in f_yy so it rendered like f_{y}*y. Added them.
pg 60: I think the "in" in "(1, 3) is a stable solution *in* which all solutions spiral towards" is redundant
pg: 63: Should be "wave in one dimension" instead of "wave in one dimension*s*"