### PR TITLE
refer to example

### DIFF
--- a/IA_M/differential_equations.tex
+++ b/IA_M/differential_equations.tex
@@ -2454,7 +2454,7 @@ In general, there are three possible cases of $\mathbf{\dot{Y}} = M\mathbf{Y}$ c
         \draw [mblue, semithick, domain = 0:40,samples=300] plot ({2*exp(-\x/10)*cos(50*\x)}, {2*exp(-\x/10)*sin(50*\x)});
       \end{tikzpicture}
     \end{center}
-    If $\Re (\lambda_{1, 2}) < 0$, then it spirals inwards. If $\Re (\lambda_{1, 2}) > 0$, then it spirals outwards. If $\Re (\lambda_{1, 2}) = 0$, then we have ellipses with common centers instead of spirals. We can determine whether the spiral is positive (as shown above), or negative (mirror image of the spiral above) by considering the eigenvectors.
+    If $\Re (\lambda_{1, 2}) < 0$, then it spirals inwards. If $\Re (\lambda_{1, 2}) > 0$, then it spirals outwards. If $\Re (\lambda_{1, 2}) = 0$, then we have ellipses with common centers instead of spirals. We can determine whether the spiral is positive (as shown above), or negative (mirror image of the spiral above) by considering the eigenvectors. An example of this is given below.
 \end{enumerate}
 
 \subsection{Nonlinear dynamical systems}


### PR DESCRIPTION
If the last part of this section simply comments that the nature of the spiral can be determined by considering the eigenvectors, the reader may panic and assume that they are supposed to understand immediately how to do this. We must point them to the example given in the next section.