### PR TITLE
reword for readability

### DIFF
--- a/IA_M/differential_equations.tex
+++ b/IA_M/differential_equations.tex
@@ -1562,7 +1562,7 @@ So we have
 \[
   \ddot x + \frac{l}{M}\dot x + \frac{k}{M}x = \frac{1}{M}F(t).
 \]
-Note that if we don't have the damping and the forcing, we end up with a simple harmonic motion with angular frequency $\sqrt{k/M}$. Write $t = \tau \sqrt{M/k}$, where $\tau$ is dimensionless. The timescale $\sqrt{M/k}$ is proportional to the period of the undamped, unforced system (or 1 over its natural frequency). Then we obtain
+Note that if we don't have the damping and the forcing, we end up with simple harmonic motion of angular frequency $\sqrt{k/M}$. Write $t = \tau \sqrt{M/k}$, where $\tau$ is dimensionless. The timescale $\sqrt{M/k}$ is proportional to the period of the undamped, unforced system (or 1 over its natural frequency). Then we obtain
 \[
   \ddot x + 2\kappa\dot x + x = f(\tau)
 \]


### PR DESCRIPTION
"a simple harmonic motion" -> "simple harmonic motion"
Although the former is perfectly correct, the latter is probably more readable.

(Also, "with" -> "of" so that "with" is not duplicated.)