### PR TITLE
implement support for more compilers

### DIFF
--- a/header.tex
+++ b/header.tex
@@ -184,10 +184,9 @@
 %%%%% Maths Symbols %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%
 
-% hyperref may have set some macros which we want to use ourselves, so we unset them here.
-\let\U\undefined
-\let\C\undefined
-\let\G\undefined
+\let\U\relax
+\let\C\relax
+\let\G\relax
 
 % Matrix groups
 \newcommand{\GL}{\mathrm{GL}}

--- a/header.tex
+++ b/header.tex
@@ -38,16 +38,14 @@
 \indexsetup{othercode={\lhead{\emph{Index}}}}
 
 \ifx \nextra \undefined
-  \usepackage[pdftex,
-    hidelinks,
+  \usepackage[hidelinks,
     pdfauthor={Dexter Chua},
     pdfsubject={Cambridge Maths Notes: Part \npart\ - \ncourse},
     pdftitle={Part \npart\ - \ncourse},
   pdfkeywords={Cambridge Mathematics Maths Math \npart\ \nterm\ \nyear\ \ncourse}]{hyperref}
   \title{Part \npart\ --- \ncourse}
 \else
-  \usepackage[pdftex,
-    hidelinks,
+  \usepackage[hidelinks,
     pdfauthor={Dexter Chua},
     pdfsubject={Cambridge Maths Notes: Part \npart\ - \ncourse\ (\nextra)},
     pdftitle={Part \npart\ - \ncourse\ (\nextra)},

--- a/header.tex
+++ b/header.tex
@@ -184,6 +184,11 @@
 %%%%% Maths Symbols %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%
 
+% hyperref may have set some macros which we want to use ourselves, so we unset them here.
+\let\U\undefined
+\let\C\undefined
+\let\G\undefined
+
 % Matrix groups
 \newcommand{\GL}{\mathrm{GL}}
 \newcommand{\Or}{\mathrm{O}}


### PR DESCRIPTION
Currently, the notes in this repository cannot be compiled with LuaLaTeX or XeLaTeX, due to an issue with conflicting single-letter macros.

This branch implements a simple workaround that adds support for LuaLaTeX and XeLaTeX, so we are no longer restricted to using pdfLaTeX.