### PR TITLE
minor typos

### DIFF
--- a/IB_L/complex_analysis.tex
+++ b/IB_L/complex_analysis.tex
@@ -12,7 +12,7 @@
 \maketitle
 {\small
 \noindent\textbf{Analytic functions}\\
-Complex differentiation and the Cauchy-Riemann equations. Examples. Conformal mappings. Informal discussion of branch points, examples of $\log z$ and $z^c$.\hspace*{\fill} [3]
+Complex differentiation and the Cauchy--Riemann equations. Examples. Conformal mappings. Informal discussion of branch points, examples of $\log z$ and $z^c$.\hspace*{\fill} [3]
 
 \vspace{10pt}
 \noindent\textbf{Contour integration and Cauchy's theorem}\\
@@ -108,7 +108,7 @@ This allows us to come up with a nice criterion for when a complex function is d
     u_x &= v_y,\\
     u_y &= -v_x.
   \end{align*}
-  These equations are the \emph{Cauchy-Riemann equations}. In this case, we have
+  These equations are the \emph{Cauchy--Riemann equations}. In this case, we have
   \[
     f'(w) = u_x(c, d) + iv_x(c, d) = v_y(c, d) -i u_y(c, d).
   \]
@@ -121,7 +121,7 @@ This allows us to come up with a nice criterion for when a complex function is d
   \]
   If $z = x + iy$, then
   \[
-    (p + iq) (z - w) = p(x - c) - q(y - d) + i(q(x - c) + p (y - c)).
+    (p + iq) (z - w) = p(x - c) - q(y - d) + i(q(x - c) + p (y - d)).
   \]
   So, breaking into real and imaginary parts, we know $(\dagger)$ holds if and only if
   \[
@@ -151,7 +151,7 @@ A standard warning is given that $f: U \to \C$ can be written as $f = u + iv$, w
       \[
         u_x = \frac{x}{\sqrt{x^2 + y^2}},\quad u_y = \frac{y}{\sqrt{x^2 + y^2}}.
       \]
-      If we are not at the origin, then clearly we cannot have both vanish vanishing, but the partials of $v$ both vanish. Hence the Cauchy-Riemann equations do not hold and it is not differentiable outside of the origin.
+      If we are not at the origin, then clearly we cannot have both vanish, but the partials of $v$ both vanish. Hence the Cauchy--Riemann equations do not hold and it is not differentiable outside of the origin.
 
       At the origin, we can compute directly that
       \[
@@ -205,7 +205,7 @@ What else can we do with conformal maps? It turns out we can use it to solve Lap
 
 We will later prove that if $f: U \to \C$ is holomorphic on an open set $U$, then $f': U \to \C$ is \emph{also} holomorphic. Hence $f$ is infinitely differentiable.
 
-In particular, if we write $f = u + iv$, then using the formula for $f'$ in terms of the partials, we know $u$ and $v$ are also \emph{infinitely differentiable}. Differentiating the Cauchy-Riemann equations, we get
+In particular, if we write $f = u + iv$, then using the formula for $f'$ in terms of the partials, we know $u$ and $v$ are also \emph{infinitely differentiable}. Differentiating the Cauchy--Riemann equations, we get
 \[
   u_{xx} = v_{yx} = -u_{yy}.
 \]
@@ -1236,7 +1236,7 @@ Recall that we previously computed $\int_{\partial \overline{B(0, 1)}} \frac{1}{
     &\leq \sup_{|z - w| = \rho} |f(w)|\\
     &\leq f(z).
   \end{align*}
-  So we must have equality throughout. When we proved the supremum bound for the integral, we showed equality can happen only if the integrand is constant. So $|f(w)|$ is constant on the circle $|z - w| = \rho$, and is equal to $f(z)$. Since this is true for all $\rho \in (0, r)$, it follows that $|f|$ is constant on $B(z; r)$. Then the Cauchy-Riemann equations then entail that $f$ must be constant, as you have shown in example sheet 1.
+  So we must have equality throughout. When we proved the supremum bound for the integral, we showed equality can happen only if the integrand is constant. So $|f(w)|$ is constant on the circle $|z - w| = \rho$, and is equal to $f(z)$. Since this is true for all $\rho \in (0, r)$, it follows that $|f|$ is constant on $B(z; r)$. Then the Cauchy--Riemann equations then entail that $f$ must be constant, as you have shown in example sheet 1.
 \end{proof}
 Going back to the Cauchy integral formula, recall that we had $\overline{B(z_0; r)} \subseteq U$, $f: U \to C$ holomorphic, and we want to show
 \[
@@ -1425,11 +1425,11 @@ This tells us every holomorphic function behaves like a power series. In particu
 This justifies our claim from the very beginning that $\Re(f)$ and $\Im(f)$ are harmonic functions if $f$ is holomorphic.
 
 \begin{cor}
-  If $f: U\to \C$ is a complex-valued function, then $f = u + iv$ is holomorphic at $p \in U$ if and only if $u, v$ satisfy the Cauchy-Riemann equations, and that $u_x, u_y, v_x, v_y$ are continuous in a neighbourhood of $p$.
+  If $f: U\to \C$ is a complex-valued function, then $f = u + iv$ is holomorphic at $p \in U$ if and only if $u, v$ satisfy the Cauchy--Riemann equations, and that $u_x, u_y, v_x, v_y$ are continuous in a neighbourhood of $p$.
 \end{cor}
 
 \begin{proof}
-  If $u_x, u_y, v_x, v_y$ exist and are continuous in an open neighbourhood of $p$, then $u$ and $v$ are differentiable as functions $\R^2 \to \R^2$ at $p$, and then we proved that the Cauchy-Riemann equations imply differentiability at each point in the neighbourhood of $p$. So $f$ is differentiable at a neighbourhood of $p$.
+  If $u_x, u_y, v_x, v_y$ exist and are continuous in an open neighbourhood of $p$, then $u$ and $v$ are differentiable as functions $\R^2 \to \R^2$ at $p$, and then we proved that the Cauchy--Riemann equations imply differentiability at each point in the neighbourhood of $p$. So $f$ is differentiable at a neighbourhood of $p$.
 
   On the other hand, if $f$ is holomorphic, then it is infinitely differentiable. In particular, $f'(z)$ is also holomorphic. So $u_x, u_y, v_x, v_y$ are differentiable, hence continuous.
 \end{proof}


### PR DESCRIPTION
In Complex Analysis (IB_L):

line 124: "p(y - c)" -> "p(y - d)"
line 154: "vanish vanishing" -> "vanish"
various: Changed "Cauchy-Riemann" to "Cauchy--Riemann" (double-named things should have an en-dash rather than a hyphen).