### PR TITLE
Add phrase for Mi and mi

### DIFF
--- a/IA_L/analysis_i.tex
+++ b/IA_L/analysis_i.tex
@@ -2488,7 +2488,7 @@ for every $x\in[a, b]$, then
 \end{prop}
 
 \begin{proof}
-  Let $C$ be such that $|f(x)|, |g(x)| \leq C$ for every $x\in [a, b]$. Write $L_i$ and $\ell_i$ for the $\sup$ and $\inf$ of $g$ in $[x_{i - 1}, x_i]$. Now let $\mathcal{D}$ be a dissection, and for each $i$, let $u_i$ and $v_i$ be two points in $[x_{i - 1}, x_i]$.
+  Let $C$ be such that $|f(x)|, |g(x)| \leq C$ for every $x\in [a, b]$. Write $L_i$ and $\ell_i$ for the $\sup$ and $\inf$ of $g$ in $[x_{i - 1}, x_i]$. Similarly write $M_i$ and $m_i$ for the $\sup$ and $\inf$ of $f$ in $[x_{i - 1}, x_i]$. Now let $\mathcal{D}$ be a dissection, and for each $i$, let $u_i$ and $v_i$ be two points in $[x_{i - 1}, x_i]$.
 
   We will pretend that $u_i$ and $v_i$ are the minimum and maximum when we write the proof, but we cannot assert that they are, since $fg$ need not have maxima and minima. We will then note that since our results hold for arbitrary $u_i$ and $v_i$, it must hold when $fg$ is at its supremum and infimum.
 


### PR DESCRIPTION
The previous statement of this proof does not seem to include a definition for $M_i$ and $m_i$, the supremum and infimum of $f$ in the $i^{th}$ interval. This PR adds a sentence defining this.