### PR TITLE
Typo in logic and set theory?

### DIFF
--- a/II_L/logic_and_set_theory.tex
+++ b/II_L/logic_and_set_theory.tex
@@ -127,7 +127,7 @@ It should be clear that a valuation is uniquely determined by its values on the 
 \begin{prop}\leavevmode
   \begin{enumerate}
     \item If $v$ and $v'$ are valuations with $v(p) = v'(p)$ for all $p\in P$, then $v = v'$.
-    \item For any function $w: P \to \{0, 1\}$, we can extend it to a valuation $v$ such that $v(p) = w(p)$ for all $p\in L$.
+    \item For any function $w: P \to \{0, 1\}$, we can extend it to a valuation $v$ such that $v(p) = w(p)$ for all $p\in P$.
   \end{enumerate}
 \end{prop}
 


### PR DESCRIPTION
The domain of w is P, but the original statement would mean the domain needs to be L. Presumably w and its extension, v, only need to agree on P?